### PR TITLE
Subscription timestamps

### DIFF
--- a/InputHandlers.Sample/InputHandler.cs
+++ b/InputHandlers.Sample/InputHandler.cs
@@ -10,277 +10,276 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Sample
+namespace InputHandlers.Sample;
+
+public class InputHandler : IMouseHandler, IKeyboardHandler
 {
-    public class InputHandler : IMouseHandler, IKeyboardHandler
+    private enum KeyboardLabelTypes
     {
-        private enum KeyboardLabelTypes
-        {
-            CurrentState,
-            KeyDown,
-            KeyLost,
-            KeyRepeat,
-            KeysReleased,
-            RunningKeys,
-            Example
-        };
+        CurrentState,
+        KeyDown,
+        KeyLost,
+        KeyRepeat,
+        KeysReleased,
+        RunningKeys,
+        Example
+    };
 
-        private enum MouseLabelTypes
-        {
-            CurrentState,
-            ScrollWheel,
-            Moving,
-            LeftClick,
-            LeftDoubleClick,
-            LeftDown,
-            LeftUp,
-            LeftDragging,
-            LeftDraggingDone,
-            RightClick,
-            RightDoubleClick,
-            RightDown,
-            RightUp,
-            RightDragging,
-            RightDraggingDone,
-            MiddleClick,
-            MiddleDoubleClick,
-            MiddleDown,
-            MiddleUp,
-            MiddleDragging,
-            MiddleDraggingDone
-        }
+    private enum MouseLabelTypes
+    {
+        CurrentState,
+        ScrollWheel,
+        Moving,
+        LeftClick,
+        LeftDoubleClick,
+        LeftDown,
+        LeftUp,
+        LeftDragging,
+        LeftDraggingDone,
+        RightClick,
+        RightDoubleClick,
+        RightDown,
+        RightUp,
+        RightDragging,
+        RightDraggingDone,
+        MiddleClick,
+        MiddleDoubleClick,
+        MiddleDown,
+        MiddleUp,
+        MiddleDragging,
+        MiddleDraggingDone
+    }
 
-        private Dictionary<KeyboardLabelTypes, SimpleLabel> _keyboardLabels;
-        private Dictionary<MouseLabelTypes, SimpleLabel> _mouseLabels;
-        private Stopwatch _realTimer;
+    private Dictionary<KeyboardLabelTypes, SimpleLabel> _keyboardLabels;
+    private Dictionary<MouseLabelTypes, SimpleLabel> _mouseLabels;
+    private Stopwatch _realTimer;
 
-        public void HandleKeyboardKeyDown(Keys[] keysDown, Keys keyInFocus, KeyboardModifier keyboardModifier)
-        {
-            _keyboardLabels[KeyboardLabelTypes.KeyDown].HighlightRed(_realTimer);
-            WriteCurrentKeysToTextbox(keysDown, keyboardModifier);
-            WriteTextToTextbox(keyInFocus, keyboardModifier);
-        }
+    public void HandleKeyboardKeyDown(Keys[] keysDown, Keys keyInFocus, KeyboardModifier keyboardModifier)
+    {
+        _keyboardLabels[KeyboardLabelTypes.KeyDown].HighlightRed(_realTimer);
+        WriteCurrentKeysToTextbox(keysDown, keyboardModifier);
+        WriteTextToTextbox(keyInFocus, keyboardModifier);
+    }
 
-        public void HandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier)
-        {
-            _keyboardLabels[KeyboardLabelTypes.KeyLost].HighlightRed(_realTimer);
-            WriteCurrentKeysToTextbox(keysDown, keyboardModifier);
-        }
+    public void HandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier)
+    {
+        _keyboardLabels[KeyboardLabelTypes.KeyLost].HighlightRed(_realTimer);
+        WriteCurrentKeysToTextbox(keysDown, keyboardModifier);
+    }
 
-        public void HandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier)
-        {
-            _keyboardLabels[KeyboardLabelTypes.KeyRepeat].Activate();
-            WriteTextToTextbox(repeatingKey, keyboardModifier);
-        }
+    public void HandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier)
+    {
+        _keyboardLabels[KeyboardLabelTypes.KeyRepeat].Activate();
+        WriteTextToTextbox(repeatingKey, keyboardModifier);
+    }
 
-        public void HandleKeyboardKeysReleased()
-        {
-            _keyboardLabels[KeyboardLabelTypes.KeysReleased].HighlightRed(_realTimer);
-            _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text = "Running Keys: ";
-            _keyboardLabels[KeyboardLabelTypes.Example].Text = "No Keys Down";
-        }
+    public void HandleKeyboardKeysReleased()
+    {
+        _keyboardLabels[KeyboardLabelTypes.KeysReleased].HighlightRed(_realTimer);
+        _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text = "Running Keys: ";
+        _keyboardLabels[KeyboardLabelTypes.Example].Text = "No Keys Down";
+    }
 
-        public void HandleMouseScrollWheelMove(MouseState mouseState, int difference)
-        {
-            _mouseLabels[MouseLabelTypes.ScrollWheel].HighlightRed(_realTimer);
-        }
+    public void HandleMouseScrollWheelMove(MouseState mouseState, int difference)
+    {
+        _mouseLabels[MouseLabelTypes.ScrollWheel].HighlightRed(_realTimer);
+    }
 
-        public void HandleMouseMoving(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.Moving].Activate();
-        }
+    public void HandleMouseMoving(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.Moving].Activate();
+    }
 
-        public void HandleLeftMouseClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftClick].HighlightRed(_realTimer);
-        }
+    public void HandleLeftMouseClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleLeftMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftDoubleClick].HighlightRed(_realTimer);
-        }
+    public void HandleLeftMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftDoubleClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleLeftMouseDown(MouseState mouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftDown].Activate();
-        }
+    public void HandleLeftMouseDown(MouseState mouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftDown].Activate();
+    }
 
-        public void HandleLeftMouseUp(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.LeftUp].HighlightRed(_realTimer);
-        }
+    public void HandleLeftMouseUp(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.LeftUp].HighlightRed(_realTimer);
+    }
 
-        public void HandleLeftMouseDragging(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.LeftDragging].Activate();
-        }
+    public void HandleLeftMouseDragging(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.LeftDragging].Activate();
+    }
 
-        public void HandleLeftMouseDragDone(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.LeftDragging].Deactivate();
-            _mouseLabels[MouseLabelTypes.LeftDraggingDone].HighlightRed(_realTimer);
-        }
+    public void HandleLeftMouseDragDone(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.LeftDragging].Deactivate();
+        _mouseLabels[MouseLabelTypes.LeftDraggingDone].HighlightRed(_realTimer);
+    }
 
-        public void HandleRightMouseClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightClick].HighlightRed(_realTimer);
-        }
+    public void HandleRightMouseClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleRightMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightDoubleClick].HighlightRed(_realTimer);
-        }
+    public void HandleRightMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightDoubleClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleRightMouseDown(MouseState mouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightDown].Activate();
-        }
+    public void HandleRightMouseDown(MouseState mouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightDown].Activate();
+    }
 
-        public void HandleRightMouseUp(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.RightUp].HighlightRed(_realTimer);
-        }
+    public void HandleRightMouseUp(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.RightUp].HighlightRed(_realTimer);
+    }
 
-        public void HandleRightMouseDragging(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.RightDragging].Activate();
-        }
+    public void HandleRightMouseDragging(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.RightDragging].Activate();
+    }
 
-        public void HandleRightMouseDragDone(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.RightDragging].Deactivate();
-            _mouseLabels[MouseLabelTypes.RightDraggingDone].HighlightRed(_realTimer);
-        }
+    public void HandleRightMouseDragDone(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.RightDragging].Deactivate();
+        _mouseLabels[MouseLabelTypes.RightDraggingDone].HighlightRed(_realTimer);
+    }
 
-        public void HandleMiddleMouseClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleClick].HighlightRed(_realTimer);
-        }
+    public void HandleMiddleMouseClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleMiddleMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleDoubleClick].HighlightRed(_realTimer);
-        }
+    public void HandleMiddleMouseDoubleClick(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleDoubleClick].HighlightRed(_realTimer);
+    }
 
-        public void HandleMiddleMouseDown(MouseState mouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleDown].Activate();
-        }
+    public void HandleMiddleMouseDown(MouseState mouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleDown].Activate();
+    }
 
-        public void HandleMiddleMouseUp(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.MiddleUp].HighlightRed(_realTimer);
-        }
+    public void HandleMiddleMouseUp(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.MiddleUp].HighlightRed(_realTimer);
+    }
 
-        public void HandleMiddleMouseDragging(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleDown].Deactivate();
-            _mouseLabels[MouseLabelTypes.MiddleDragging].Activate();
-        }
+    public void HandleMiddleMouseDragging(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleDown].Deactivate();
+        _mouseLabels[MouseLabelTypes.MiddleDragging].Activate();
+    }
 
-        public void HandleMiddleMouseDragDone(MouseState mouseState, MouseState originalMouseState)
-        {
-            _mouseLabels[MouseLabelTypes.MiddleDragging].Deactivate();
-            _mouseLabels[MouseLabelTypes.MiddleDraggingDone].HighlightRed(_realTimer);
-        }
+    public void HandleMiddleMouseDragDone(MouseState mouseState, MouseState originalMouseState)
+    {
+        _mouseLabels[MouseLabelTypes.MiddleDragging].Deactivate();
+        _mouseLabels[MouseLabelTypes.MiddleDraggingDone].HighlightRed(_realTimer);
+    }
 
-        public void Initialise()
-        {
-            _realTimer = new Stopwatch();
-            _realTimer.Start();
+    public void Initialise()
+    {
+        _realTimer = new Stopwatch();
+        _realTimer.Start();
 
-            _mouseLabels = new Dictionary<MouseLabelTypes, SimpleLabel>();
-            _keyboardLabels = new Dictionary<KeyboardLabelTypes, SimpleLabel>();
+        _mouseLabels = new Dictionary<MouseLabelTypes, SimpleLabel>();
+        _keyboardLabels = new Dictionary<KeyboardLabelTypes, SimpleLabel>();
 
-            var currentPosition = new Vector2(400.0f, 30.0f);
-            var gap = new Vector2(0.0f, 30.0f);
+        var currentPosition = new Vector2(400.0f, 30.0f);
+        var gap = new Vector2(0.0f, 30.0f);
 
-            _keyboardLabels.Add(KeyboardLabelTypes.CurrentState, new SimpleLabel(currentPosition += gap, "Current State: "));
-            _keyboardLabels.Add(KeyboardLabelTypes.KeyDown, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyDown Fired"));
-            _keyboardLabels.Add(KeyboardLabelTypes.KeyLost, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyLost Fired"));
-            _keyboardLabels.Add(KeyboardLabelTypes.KeyRepeat, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyRepeat Fired"));
-            _keyboardLabels.Add(KeyboardLabelTypes.KeysReleased, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeysReleased Fired"));
-            _keyboardLabels.Add(KeyboardLabelTypes.RunningKeys, new SimpleLabel(currentPosition += gap, "Running Keys: "));
-            _keyboardLabels.Add(KeyboardLabelTypes.Example, new SimpleLabel(currentPosition += gap, "Textbox Text Example: "));
+        _keyboardLabels.Add(KeyboardLabelTypes.CurrentState, new SimpleLabel(currentPosition += gap, "Current State: "));
+        _keyboardLabels.Add(KeyboardLabelTypes.KeyDown, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyDown Fired"));
+        _keyboardLabels.Add(KeyboardLabelTypes.KeyLost, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyLost Fired"));
+        _keyboardLabels.Add(KeyboardLabelTypes.KeyRepeat, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeyRepeat Fired"));
+        _keyboardLabels.Add(KeyboardLabelTypes.KeysReleased, new SimpleLabel(currentPosition += gap, "HandleKeyboardKeysReleased Fired"));
+        _keyboardLabels.Add(KeyboardLabelTypes.RunningKeys, new SimpleLabel(currentPosition += gap, "Running Keys: "));
+        _keyboardLabels.Add(KeyboardLabelTypes.Example, new SimpleLabel(currentPosition += gap, "Textbox Text Example: "));
 
-            currentPosition = new Vector2(30.0f, 30.0f);
+        currentPosition = new Vector2(30.0f, 30.0f);
 
-            _mouseLabels.Add(MouseLabelTypes.CurrentState, new SimpleLabel(currentPosition += gap, "Current State: "));
-            _mouseLabels.Add(MouseLabelTypes.ScrollWheel, new SimpleLabel(currentPosition += gap, "HandleMouseScrollWheelMove Fired"));
-            _mouseLabels.Add(MouseLabelTypes.Moving, new SimpleLabel(currentPosition += gap, "HandleMouseMoving Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftClick, new SimpleLabel(currentPosition += gap, "HandleLeftMouseClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftDoubleClick, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDoubleClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftDown, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDown Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftUp, new SimpleLabel(currentPosition += gap, "HandleLeftMouseUp Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftDragging, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDragging Fired"));
-            _mouseLabels.Add(MouseLabelTypes.LeftDraggingDone, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDragDone Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightClick, new SimpleLabel(currentPosition += gap, "HandleRightMouseClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightDoubleClick, new SimpleLabel(currentPosition += gap, "HandleRightMouseDoubleClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightDown, new SimpleLabel(currentPosition += gap, "HandleRightMouseDown Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightUp, new SimpleLabel(currentPosition += gap, "HandleRightMouseUp Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightDragging, new SimpleLabel(currentPosition += gap, "HandleRightMouseDragging Fired"));
-            _mouseLabels.Add(MouseLabelTypes.RightDraggingDone, new SimpleLabel(currentPosition += gap, "HandleRightMouseDragDone Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleClick, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleDoubleClick, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDoubleClick Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleDown, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDown Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleUp, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseUp Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleDragging, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDragging Fired"));
-            _mouseLabels.Add(MouseLabelTypes.MiddleDraggingDone, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDragDone Fired"));
-        }
+        _mouseLabels.Add(MouseLabelTypes.CurrentState, new SimpleLabel(currentPosition += gap, "Current State: "));
+        _mouseLabels.Add(MouseLabelTypes.ScrollWheel, new SimpleLabel(currentPosition += gap, "HandleMouseScrollWheelMove Fired"));
+        _mouseLabels.Add(MouseLabelTypes.Moving, new SimpleLabel(currentPosition += gap, "HandleMouseMoving Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftClick, new SimpleLabel(currentPosition += gap, "HandleLeftMouseClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftDoubleClick, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDoubleClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftDown, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDown Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftUp, new SimpleLabel(currentPosition += gap, "HandleLeftMouseUp Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftDragging, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDragging Fired"));
+        _mouseLabels.Add(MouseLabelTypes.LeftDraggingDone, new SimpleLabel(currentPosition += gap, "HandleLeftMouseDragDone Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightClick, new SimpleLabel(currentPosition += gap, "HandleRightMouseClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightDoubleClick, new SimpleLabel(currentPosition += gap, "HandleRightMouseDoubleClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightDown, new SimpleLabel(currentPosition += gap, "HandleRightMouseDown Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightUp, new SimpleLabel(currentPosition += gap, "HandleRightMouseUp Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightDragging, new SimpleLabel(currentPosition += gap, "HandleRightMouseDragging Fired"));
+        _mouseLabels.Add(MouseLabelTypes.RightDraggingDone, new SimpleLabel(currentPosition += gap, "HandleRightMouseDragDone Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleClick, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleDoubleClick, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDoubleClick Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleDown, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDown Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleUp, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseUp Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleDragging, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDragging Fired"));
+        _mouseLabels.Add(MouseLabelTypes.MiddleDraggingDone, new SimpleLabel(currentPosition += gap, "HandleMiddleMouseDragDone Fired"));
+    }
 
-        public void UpdateLabelsBeforePoll()
-        {
-            _mouseLabels[MouseLabelTypes.Moving].Deactivate();
-            _keyboardLabels[KeyboardLabelTypes.KeyRepeat].Deactivate();
-        }
+    public void UpdateLabelsBeforePoll()
+    {
+        _mouseLabels[MouseLabelTypes.Moving].Deactivate();
+        _keyboardLabels[KeyboardLabelTypes.KeyRepeat].Deactivate();
+    }
 
-        public void UpdateLabelsAfterPoll(GameTime gameTime, MouseInput mouseInput, Keyboard.KeyboardInput keyboardInput)
-        {
-            _mouseLabels[MouseLabelTypes.CurrentState].Text = "Current State: " + mouseInput.CurrentStateAsString();
-            _keyboardLabels[KeyboardLabelTypes.CurrentState].Text = "Current State: " + keyboardInput.GetCurrentStateTypeName();
+    public void UpdateLabelsAfterPoll(GameTime gameTime, MouseInput mouseInput, Keyboard.KeyboardInput keyboardInput)
+    {
+        _mouseLabels[MouseLabelTypes.CurrentState].Text = "Current State: " + mouseInput.CurrentStateAsString();
+        _keyboardLabels[KeyboardLabelTypes.CurrentState].Text = "Current State: " + keyboardInput.GetCurrentStateTypeName();
 
-            foreach (var label in _mouseLabels.Values)
-                label.Update(gameTime, _realTimer);
+        foreach (var label in _mouseLabels.Values)
+            label.Update(gameTime, _realTimer);
 
-            foreach (var label in _keyboardLabels.Values)
-                label.Update(gameTime, _realTimer);
-        }
+        foreach (var label in _keyboardLabels.Values)
+            label.Update(gameTime, _realTimer);
+    }
 
-        public void DrawLabels(SpriteBatch spriteBatch, SpriteFont spriteFont)
-        {
-            foreach (var label in _mouseLabels.Values)
-                label.Draw(spriteBatch, spriteFont);
+    public void DrawLabels(SpriteBatch spriteBatch, SpriteFont spriteFont)
+    {
+        foreach (var label in _mouseLabels.Values)
+            label.Draw(spriteBatch, spriteFont);
 
-            foreach (var label in _keyboardLabels.Values)
-                label.Draw(spriteBatch, spriteFont);
-        }
+        foreach (var label in _keyboardLabels.Values)
+            label.Draw(spriteBatch, spriteFont);
+    }
 
-        public void WriteTextToTextbox(Keys focus, KeyboardModifier keyboardModifier)
-        {
-            _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text += focus.Display(keyboardModifier);
+    public void WriteTextToTextbox(Keys focus, KeyboardModifier keyboardModifier)
+    {
+        _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text += focus.Display(keyboardModifier);
 
-            if ((focus == Keys.Back) && (_keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Length > 22))
-                _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text = _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Remove(_keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Length - 1, 1);
-        }
+        if ((focus == Keys.Back) && (_keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Length > 22))
+            _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text = _keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Remove(_keyboardLabels[KeyboardLabelTypes.RunningKeys].Text.Length - 1, 1);
+    }
 
-        public void WriteCurrentKeysToTextbox(Keys[] keyList, KeyboardModifier keyboardModifier)
-        {
-            // Note - sometimes more than 2 keys wont register.  See this for explanation of keyboard hardware limitations:
-            // http://blogs.msdn.com/shawnhar/archive/2007/03/28/keyboards-suck.aspx
-            _keyboardLabels[KeyboardLabelTypes.Example].Text = "Current Keys: ";
-            foreach (var k in keyList)
-                _keyboardLabels[KeyboardLabelTypes.Example].Text += k.ToString();
-            if ((KeyboardModifier.Alt & keyboardModifier) == KeyboardModifier.Alt)
-                _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Alt ";
-            if ((KeyboardModifier.Shift & keyboardModifier) == KeyboardModifier.Shift)
-                _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Shift ";
-            if ((KeyboardModifier.Ctrl & keyboardModifier) == KeyboardModifier.Ctrl)
-                _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Ctrl ";
-        }
+    public void WriteCurrentKeysToTextbox(Keys[] keyList, KeyboardModifier keyboardModifier)
+    {
+        // Note - sometimes more than 2 keys wont register.  See this for explanation of keyboard hardware limitations:
+        // http://blogs.msdn.com/shawnhar/archive/2007/03/28/keyboards-suck.aspx
+        _keyboardLabels[KeyboardLabelTypes.Example].Text = "Current Keys: ";
+        foreach (var k in keyList)
+            _keyboardLabels[KeyboardLabelTypes.Example].Text += k.ToString();
+        if ((KeyboardModifier.Alt & keyboardModifier) == KeyboardModifier.Alt)
+            _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Alt ";
+        if ((KeyboardModifier.Shift & keyboardModifier) == KeyboardModifier.Shift)
+            _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Shift ";
+        if ((KeyboardModifier.Ctrl & keyboardModifier) == KeyboardModifier.Ctrl)
+            _keyboardLabels[KeyboardLabelTypes.Example].Text += " +Ctrl ";
     }
 }

--- a/InputHandlers.Sample/InputHandlersSample.cs
+++ b/InputHandlers.Sample/InputHandlersSample.cs
@@ -8,86 +8,85 @@ using InputHandlers.Mouse;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace InputHandlers.Sample
+namespace InputHandlers.Sample;
+
+public class InputHandlersSample : Game
 {
-    public class InputHandlersSample : Game
+    private const int _screenWidth = 1400;
+    private const int _screenHeight = 800;
+    private KeyboardInput _keyboard;
+    private MouseInput _mouse;
+    private SpriteFont _arialfont;
+    private readonly GraphicsDeviceManager _graphics;
+    private InputHandler _inputHandler;
+    private SpriteBatch _spriteBatch;
+
+    public InputHandlersSample()
     {
-        private const int _screenWidth = 1400;
-        private const int _screenHeight = 800;
-        private KeyboardInput _keyboard;
-        private MouseInput _mouse;
-        private SpriteFont _arialfont;
-        private readonly GraphicsDeviceManager _graphics;
-        private InputHandler _inputHandler;
-        private SpriteBatch _spriteBatch;
+        _graphics = new GraphicsDeviceManager(this);
 
-        public InputHandlersSample()
-        {
-            _graphics = new GraphicsDeviceManager(this);
+        _graphics.PreferredBackBufferWidth = _screenWidth;
+        _graphics.PreferredBackBufferHeight = _screenHeight;
 
-            _graphics.PreferredBackBufferWidth = _screenWidth;
-            _graphics.PreferredBackBufferHeight = _screenHeight;
+        Content.RootDirectory = "Content";
 
-            Content.RootDirectory = "Content";
+        IsFixedTimeStep = false;
+    }
 
-            IsFixedTimeStep = false;
-        }
+    protected override void Initialize()
+    {
+        _mouse = new MouseInput();
+        _keyboard = new KeyboardInput();
 
-        protected override void Initialize()
-        {
-            _mouse = new MouseInput();
-            _keyboard = new KeyboardInput();
+        // You may want to assign keys that are unmanaged by the handler.  For example, you might want to handle the ASDW keys yourself in a fps game.
+        // Try uncommenting the following and notice how nothing will happen when you press the keys:
+        // _keyboard.UnmanagedKeys.Add(Keys.A);
+        // _keyboard.UnmanagedKeys.Add(Keys.S);
+        // _keyboard.UnmanagedKeys.Add(Keys.D);
+        // _keyboard.UnmanagedKeys.Add(Keys.W);
 
-            // You may want to assign keys that are unmanaged by the handler.  For example, you might want to handle the ASDW keys yourself in a fps game.
-            // Try uncommenting the following and notice how nothing will happen when you press the keys:
-            // _keyboard.UnmanagedKeys.Add(Keys.A);
-            // _keyboard.UnmanagedKeys.Add(Keys.S);
-            // _keyboard.UnmanagedKeys.Add(Keys.D);
-            // _keyboard.UnmanagedKeys.Add(Keys.W);
+        // You may want to treat control, alt and delete as keys rather than modifier keys.  Try uncommenting the following line to see this behaviour:
+        // _keyboard.TreatModifiersAsKeys = true;
 
-            // You may want to treat control, alt and delete as keys rather than modifier keys.  Try uncommenting the following line to see this behaviour:
-            // _keyboard.TreatModifiersAsKeys = true;
+        _inputHandler = new InputHandler();
+        _inputHandler.Initialise();
 
-            _inputHandler = new InputHandler();
-            _inputHandler.Initialise();
+        _mouse.Subscribe(_inputHandler);
+        _keyboard.Subscribe(_inputHandler);
 
-            _mouse.Subscribe(_inputHandler);
-            _keyboard.Subscribe(_inputHandler);
+        base.Initialize();
+    }
 
-            base.Initialize();
-        }
+    protected override void LoadContent()
+    {
+        IsMouseVisible = true;
 
-        protected override void LoadContent()
-        {
-            IsMouseVisible = true;
+        _spriteBatch = new SpriteBatch(GraphicsDevice);
+        _arialfont = Content.Load<SpriteFont>("arial12");
+    }
 
-            _spriteBatch = new SpriteBatch(GraphicsDevice);
-            _arialfont = Content.Load<SpriteFont>("arial12");
-        }
+    protected override void Update(GameTime gameTime)
+    {
+        _inputHandler.UpdateLabelsBeforePoll();
 
-        protected override void Update(GameTime gameTime)
-        {
-            _inputHandler.UpdateLabelsBeforePoll();
+        _mouse.Poll(Microsoft.Xna.Framework.Input.Mouse.GetState());
+        _keyboard.Poll(Microsoft.Xna.Framework.Input.Keyboard.GetState());
 
-            _mouse.Poll(Microsoft.Xna.Framework.Input.Mouse.GetState());
-            _keyboard.Poll(Microsoft.Xna.Framework.Input.Keyboard.GetState());
+        _inputHandler.UpdateLabelsAfterPoll(gameTime, _mouse, _keyboard);
 
-            _inputHandler.UpdateLabelsAfterPoll(gameTime, _mouse, _keyboard);
+        base.Update(gameTime);
+    }
 
-            base.Update(gameTime);
-        }
+    protected override void Draw(GameTime gameTime)
+    {
+        _graphics.GraphicsDevice.Clear(Color.Black);
 
-        protected override void Draw(GameTime gameTime)
-        {
-            _graphics.GraphicsDevice.Clear(Color.Black);
+        _spriteBatch.Begin();
 
-            _spriteBatch.Begin();
+        _inputHandler.DrawLabels(_spriteBatch, _arialfont);
 
-            _inputHandler.DrawLabels(_spriteBatch, _arialfont);
+        _spriteBatch.End();
 
-            _spriteBatch.End();
-
-            base.Draw(gameTime);
-        }
+        base.Draw(gameTime);
     }
 }

--- a/InputHandlers.Sample/Program.cs
+++ b/InputHandlers.Sample/Program.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 
-namespace InputHandlers.Sample
+namespace InputHandlers.Sample;
+
+static class Program
 {
-    static class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
+        using (InputHandlersSample game = new InputHandlersSample())
         {
-            using (InputHandlersSample game = new InputHandlersSample())
-            {
-                game.Run();
-            }
+            game.Run();
         }
     }
 }

--- a/InputHandlers.Sample/SimpleLabel.cs
+++ b/InputHandlers.Sample/SimpleLabel.cs
@@ -6,69 +6,68 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace InputHandlers.Sample
+namespace InputHandlers.Sample;
+
+public class SimpleLabel
 {
-    public class SimpleLabel
+    public string Text { get; set; }
+
+    private Color _activeColour;
+    private Color _currentDrawColour;
+    private readonly Color _highlightColour;
+    private readonly Color _normalColour;
+    private readonly Vector2 _position;
+    private TimeSpan _time;
+    private double _timeRemaining;
+    private readonly double _highlightDuration = 1000.0;
+
+    public SimpleLabel(Vector2 startpos, string starttext)
     {
-        public string Text { get; set; }
+        Text = starttext;
+        _position = startpos;
+        _normalColour = Color.Gray;
+        _currentDrawColour = _normalColour;
+        _activeColour = Color.White;
+        _highlightColour = Color.Red;
+        _timeRemaining = -1.0;
+    }
 
-        private Color _activeColour;
-        private Color _currentDrawColour;
-        private readonly Color _highlightColour;
-        private readonly Color _normalColour;
-        private readonly Vector2 _position;
-        private TimeSpan _time;
-        private double _timeRemaining;
-        private readonly double _highlightDuration = 1000.0;
+    public void Draw(SpriteBatch sb, SpriteFont sf)
+    {
+        sb.DrawString(sf, Text, _position, _currentDrawColour, 0.0f, Vector2.Zero, 1.0f, SpriteEffects.None, 0);
+    }
 
-        public SimpleLabel(Vector2 startpos, string starttext)
+    public void Update(GameTime gtime, Stopwatch realTimer)
+    {
+        UpdateHighlightDuration(realTimer);
+    }
+
+    public void Activate()
+    {
+        _currentDrawColour = _activeColour;
+    }
+
+    public void Deactivate()
+    {
+        _currentDrawColour = _normalColour;
+    }
+
+    public void HighlightRed(Stopwatch realTimer)
+    {
+        _time = realTimer.Elapsed;
+        _currentDrawColour = _highlightColour;
+        _timeRemaining = _highlightDuration;
+    }
+
+    private void UpdateHighlightDuration(Stopwatch realTimer)
+    {
+        if (_currentDrawColour.Equals(_highlightColour))
         {
-            Text = starttext;
-            _position = startpos;
-            _normalColour = Color.Gray;
-            _currentDrawColour = _normalColour;
-            _activeColour = Color.White;
-            _highlightColour = Color.Red;
-            _timeRemaining = -1.0;
-        }
-
-        public void Draw(SpriteBatch sb, SpriteFont sf)
-        {
-            sb.DrawString(sf, Text, _position, _currentDrawColour, 0.0f, Vector2.Zero, 1.0f, SpriteEffects.None, 0);
-        }
-
-        public void Update(GameTime gtime, Stopwatch realTimer)
-        {
-            UpdateHighlightDuration(realTimer);
-        }
-
-        public void Activate()
-        {
-            _currentDrawColour = _activeColour;
-        }
-
-        public void Deactivate()
-        {
-            _currentDrawColour = _normalColour;
-        }
-
-        public void HighlightRed(Stopwatch realTimer)
-        {
+            _timeRemaining -= realTimer.Elapsed.TotalMilliseconds - _time.TotalMilliseconds;
             _time = realTimer.Elapsed;
-            _currentDrawColour = _highlightColour;
-            _timeRemaining = _highlightDuration;
-        }
 
-        private void UpdateHighlightDuration(Stopwatch realTimer)
-        {
-            if (_currentDrawColour.Equals(_highlightColour))
-            {
-                _timeRemaining -= realTimer.Elapsed.TotalMilliseconds - _time.TotalMilliseconds;
-                _time = realTimer.Elapsed;
-
-                if (_timeRemaining < 0)
-                    _currentDrawColour = _normalColour;
-            }
+            if (_timeRemaining < 0)
+                _currentDrawColour = _normalColour;
         }
     }
 }

--- a/InputHandlers.Tests/KeyboardInputTests.cs
+++ b/InputHandlers.Tests/KeyboardInputTests.cs
@@ -11,1517 +11,1581 @@ using NSubstitute.ClearExtensions;
 
 using KeyboardInput = InputHandlers.Keyboard.KeyboardInput;
 
-namespace InputHandlers.Tests
+namespace InputHandlers.Tests;
+
+[TestClass]
+public class KeyboardInputTests
 {
-    [TestClass]
-    public class KeyboardInputTests
+    private KeyboardInput _keyboardInput;
+    private IKeyboardHandler _keyboardHandler;
+    private TestStopwatchProvider _testStopwatchProvider;
+
+    [TestInitialize]
+    public void Setup()
     {
-        private KeyboardInput _keyboardInput;
-        private IKeyboardHandler _keyboardHandler;
-        private TestStopwatchProvider _testStopwatchProvider;
+        _testStopwatchProvider = new TestStopwatchProvider();
+        _keyboardHandler = Substitute.For<IKeyboardHandler>();
+        _keyboardInput = new KeyboardInput(_testStopwatchProvider);
 
-        [TestInitialize]
-        public void Setup()
-        {
-            _testStopwatchProvider = new TestStopwatchProvider();
-            _keyboardHandler = Substitute.For<IKeyboardHandler>();
-            _keyboardInput = new KeyboardInput(_testStopwatchProvider);
+        _keyboardInput.Subscribe(_keyboardHandler);
+    }
 
-            _keyboardInput.Subscribe(_keyboardHandler);
-        }
+    [TestMethod]
+    public void KeyboardInput_Should_Subscribe_And_Unsubscribe_Correctly()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
 
-        [TestMethod]
-        public void KeyboardInput_Should_Subscribe_And_Unsubscribe_Correctly()
-        {
-            // Arrange
-            var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+        _keyboardInput.Unsubscribe(_keyboardHandler);
 
-            _keyboardInput.Subscribe(secondKeyboardHandler);
-            _keyboardInput.Unsubscribe(_keyboardHandler);
+        var keyboardState = new KeyboardState(Keys.A);
 
-            var keyboardState = new KeyboardState(Keys.A);
+        // Act
+        _keyboardInput.Poll(keyboardState);
 
-            // Act
-            _keyboardInput.Poll(keyboardState);
+        // Assert
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
 
-            // Assert
-            _keyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        secondKeyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+    }
+    
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    public void Remove_Subscription_When_Same_Handler_Is_Also_In_Pending_Add_And_Remove_Timestamp_Is_Greater_Or_Equal_Then_Subscription_Is_Removed(int advanceTime)
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
 
-            secondKeyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-        }
+        _keyboardInput.Unsubscribe(_keyboardHandler);
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+        _testStopwatchProvider.AdvanceByMilliseconds(advanceTime);
+        _keyboardInput.Unsubscribe(secondKeyboardHandler);
 
-        [TestMethod]
-        public void KeyboardInput_Can_Subscribe_While_Within_Handler_Of_Another_Subscription()
-        {
-            // Arrange
-            var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+        var keyboardState = new KeyboardState(Keys.A);
 
-            _keyboardHandler
-                .When(k => k.HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>()))
-                .Do(ci => _keyboardInput.Subscribe(secondKeyboardHandler));
+        // Act
+        _keyboardInput.Poll(keyboardState);
 
-            var keyboardState = new KeyboardState(Keys.A);
+        // Assert
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
 
-            // Act
-            _keyboardInput.Poll(keyboardState);
+        secondKeyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+    }
+    
+    [TestMethod]
+    public void Remove_Subscription_When_Same_Handler_Is_Also_In_Pending_Add_And_Remove_Timestamp_Is_Less_Then_Subscription_Is_Added()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
 
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
+        _keyboardInput.Unsubscribe(_keyboardHandler);
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+        _keyboardInput.Unsubscribe(secondKeyboardHandler);
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _keyboardInput.Subscribe(secondKeyboardHandler);
 
-            secondKeyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        var keyboardState = new KeyboardState(Keys.A);
 
-            // Arrange - second handler should now be subscribed
-            _keyboardHandler.ClearSubstitute();
-            keyboardState = new KeyboardState(Keys.B);
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+
+        secondKeyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Can_Subscribe_While_Within_Handler_Of_Another_Subscription()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+
+        _keyboardHandler
+            .When(k => k.HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>()))
+            .Do(ci => _keyboardInput.Subscribe(secondKeyboardHandler));
+
+        var keyboardState = new KeyboardState(Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        secondKeyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+
+        // Arrange - second handler should now be subscribed
+        _keyboardHandler.ClearSubstitute();
+        keyboardState = new KeyboardState(Keys.B);
             
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
-                    Arg.Is(Keys.B),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            secondKeyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
-                    Arg.Is(Keys.B),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Can_Unsubscribe_While_Within_Handler_Of_Another_Subscription()
-        {
-            // Arrange
-            var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
-
-            _keyboardInput.Subscribe(secondKeyboardHandler);
-
-            _keyboardHandler
-                .When(k => k.HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>()))
-                .Do(ci => _keyboardInput.Unsubscribe(secondKeyboardHandler));
-
-            var keyboardState = new KeyboardState(Keys.A);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            secondKeyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            // Arrange - second handler should now be unsubscribed
-            _keyboardHandler.ClearSubstitute();
-            secondKeyboardHandler.ClearReceivedCalls();
-
-            keyboardState = new KeyboardState(Keys.B);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
-                    Arg.Is(Keys.B),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            secondKeyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Ignore_Second_Subscription_Of_Same_Handler()
-        {
-            // Arrange
-            _keyboardInput.Subscribe(_keyboardHandler);
-            var keyboardState = new KeyboardState(Keys.A);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            Assert.AreEqual(1, _keyboardHandler.ReceivedCalls().Count());
-
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Call_No_Handlers_When_Polling_With_Blank_KeyboardState()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Array.Empty<Keys>());
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Increment_UpdateNumber_On_Poll()
-        {
-            // Arrange
-            var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
-
-            _keyboardInput.Subscribe(secondKeyboardHandler);
-
-            var keyboardState = new KeyboardState();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            Assert.AreEqual(1, _keyboardInput.UpdateNumber);
-
-            // Act - poll 2
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert = poll 2
-            Assert.AreEqual(2, _keyboardInput.UpdateNumber);
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Reset_To_No_State_And_Set_UpdateNumber_To_Zero_When_Resetting()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A);
-
-            _keyboardInput.Poll(keyboardState);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Reset();
-
-            // Assert
-            Assert.AreEqual(0, _keyboardInput.UpdateNumber);
-
-            // Act - poll again with keys released, state is nothing and so no keyboard up will occur
-            var keyboardStateReleased = new KeyboardState();
-
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Broadcast_To_Both_Handlers_When_KeyboardInput_Has_Two_Subscriptions()
-        {
-            // Arrange
-            var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
-
-            _keyboardInput.Subscribe(secondKeyboardHandler);
-
-            var keyboardState = new KeyboardState(Keys.A);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            secondKeyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_When_Key_Is_Pressed(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-            var keyboardState = new KeyboardState(key);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, key)),
-                    Arg.Is(key),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeysReleased_When_Key_Is_Released(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-            var keyboardState = new KeyboardState(key);
-
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState();
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler.Received().HandleKeyboardKeysReleased();
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.CapsLock, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_With_Keys_Pressed_In_Collection_And_Focus_Key_For_Key_Last_Pressed(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardStateOldKey = new KeyboardState(oldKey);
-            _keyboardInput.Poll(keyboardStateOldKey);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            var keyboardStateNewKey = new KeyboardState(oldKey, newKey);
-
-            // Act
-            _keyboardInput.Poll(keyboardStateNewKey);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, oldKey, newKey)),
-                    Arg.Is(newKey),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.CapsLock, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_If_Multiple_Keys_Down_At_Same_Time(Keys key1, Keys key2, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A, Keys.B);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
-                    Arg.Is(Keys.B),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.A, Keys.B, Keys.C, false)]
-        [DataRow(Keys.F1, Keys.CapsLock, Keys.Escape, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, Keys.PageUp, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, Keys.RightControl, true)]
-        [DataRow(Keys.A, Keys.LeftShift, Keys.RightControl, true)]
-        [DataRow(Keys.RightAlt, Keys.A, Keys.RightControl, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, Keys.A, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_With_No_Lost_Event_For_Each_Changed_Key_If_List_Of_Keys_Changed(Keys oldKey, Keys newKey1, Keys newKey2, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardStateA = new KeyboardState(oldKey);
-            _keyboardInput.Poll(keyboardStateA);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            var keyboardStateChangedKeys = new KeyboardState(newKey1, newKey2);
-
-            // Act
-            _keyboardInput.Poll(keyboardStateChangedKeys);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, newKey1, newKey2)),
-                    Arg.Is(newKey1),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, newKey1, newKey2)),
-                    Arg.Is(newKey2),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(
-                    Arg.Any<Keys[]>(),
-                    Arg.Is(oldKey),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.BrowserBack, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyLost_For_Key_Last_Released(Keys remainingKey, Keys lostKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(remainingKey);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateExtraKey = new KeyboardState(remainingKey, lostKey);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            var keyboardStateKeyLost = new KeyboardState(remainingKey);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyLost(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, remainingKey)),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                    );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Only_Call_HandleKeyboardKeyDown_Once_For_Same_State(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_Same_Keyboard_State_Is_Present_After_Delay(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
+                Arg.Is(Keys.B),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        secondKeyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
+                Arg.Is(Keys.B),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Can_Unsubscribe_While_Within_Handler_Of_Another_Subscription()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+
+        _keyboardHandler
+            .When(k => k.HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>()))
+            .Do(ci => _keyboardInput.Unsubscribe(secondKeyboardHandler));
+
+        var keyboardState = new KeyboardState(Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        secondKeyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        // Arrange - second handler should now be unsubscribed
+        _keyboardHandler.ClearSubstitute();
+        secondKeyboardHandler.ClearReceivedCalls();
+
+        keyboardState = new KeyboardState(Keys.B);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.B)),
+                Arg.Is(Keys.B),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        secondKeyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Ignore_Second_Subscription_Of_Same_Handler()
+    {
+        // Arrange
+        _keyboardInput.Subscribe(_keyboardHandler);
+        var keyboardState = new KeyboardState(Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        Assert.AreEqual(1, _keyboardHandler.ReceivedCalls().Count());
+
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Call_No_Handlers_When_Polling_With_Blank_KeyboardState()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Array.Empty<Keys>());
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Increment_UpdateNumber_On_Poll()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+
+        var keyboardState = new KeyboardState();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        Assert.AreEqual(1, _keyboardInput.UpdateNumber);
+
+        // Act - poll 2
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert = poll 2
+        Assert.AreEqual(2, _keyboardInput.UpdateNumber);
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Reset_To_No_State_And_Set_UpdateNumber_To_Zero_When_Resetting()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A);
+
+        _keyboardInput.Poll(keyboardState);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Reset();
+
+        // Assert
+        Assert.AreEqual(0, _keyboardInput.UpdateNumber);
+
+        // Act - poll again with keys released, state is nothing and so no keyboard up will occur
+        var keyboardStateReleased = new KeyboardState();
+
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Broadcast_To_Both_Handlers_When_KeyboardInput_Has_Two_Subscriptions()
+    {
+        // Arrange
+        var secondKeyboardHandler = Substitute.For<IKeyboardHandler>();
+
+        _keyboardInput.Subscribe(secondKeyboardHandler);
+
+        var keyboardState = new KeyboardState(Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        secondKeyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_When_Key_Is_Pressed(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        var keyboardState = new KeyboardState(key);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, key)),
+                Arg.Is(key),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeysReleased_When_Key_Is_Released(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        var keyboardState = new KeyboardState(key);
+
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState();
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler.Received().HandleKeyboardKeysReleased();
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.CapsLock, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_With_Keys_Pressed_In_Collection_And_Focus_Key_For_Key_Last_Pressed(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardStateOldKey = new KeyboardState(oldKey);
+        _keyboardInput.Poll(keyboardStateOldKey);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        var keyboardStateNewKey = new KeyboardState(oldKey, newKey);
+
+        // Act
+        _keyboardInput.Poll(keyboardStateNewKey);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, oldKey, newKey)),
+                Arg.Is(newKey),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.CapsLock, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_If_Multiple_Keys_Down_At_Same_Time(Keys key1, Keys key2, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A, Keys.B);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
+                Arg.Is(Keys.B),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.A, Keys.B, Keys.C, false)]
+    [DataRow(Keys.F1, Keys.CapsLock, Keys.Escape, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, Keys.PageUp, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, Keys.RightControl, true)]
+    [DataRow(Keys.A, Keys.LeftShift, Keys.RightControl, true)]
+    [DataRow(Keys.RightAlt, Keys.A, Keys.RightControl, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, Keys.A, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyDown_With_No_Lost_Event_For_Each_Changed_Key_If_List_Of_Keys_Changed(Keys oldKey, Keys newKey1, Keys newKey2, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardStateA = new KeyboardState(oldKey);
+        _keyboardInput.Poll(keyboardStateA);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        var keyboardStateChangedKeys = new KeyboardState(newKey1, newKey2);
+
+        // Act
+        _keyboardInput.Poll(keyboardStateChangedKeys);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, newKey1, newKey2)),
+                Arg.Is(newKey1),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, newKey1, newKey2)),
+                Arg.Is(newKey2),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(
+                Arg.Any<Keys[]>(),
+                Arg.Is(oldKey),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.BrowserBack, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyLost_For_Key_Last_Released(Keys remainingKey, Keys lostKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(remainingKey);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateExtraKey = new KeyboardState(remainingKey, lostKey);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        var keyboardStateKeyLost = new KeyboardState(remainingKey);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyLost(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, remainingKey)),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Only_Call_HandleKeyboardKeyDown_Once_For_Same_State(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_Same_Keyboard_State_Is_Present_After_Delay(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
             
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(key),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.BrowserBack, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyRepeat_When_Newest_Key_Is_Lost(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(key),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.BrowserBack, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyRepeat_When_Newest_Key_Is_Lost(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
 
-            var keyboardState = new KeyboardState(oldKey);
-            _keyboardInput.Poll(keyboardState);
+        var keyboardState = new KeyboardState(oldKey);
+        _keyboardInput.Poll(keyboardState);
 
-            var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
+        var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
 
-            _keyboardInput.Poll(keyboardStateExtraKey);
+        _keyboardInput.Poll(keyboardStateExtraKey);
 
-            var keyboardStateKeyLost = new KeyboardState(oldKey);
+        var keyboardStateKeyLost = new KeyboardState(oldKey);
 
-            _keyboardInput.Poll(keyboardStateKeyLost);
+        _keyboardInput.Poll(keyboardStateKeyLost);
 
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
 
-            _keyboardHandler.ClearReceivedCalls();
+        _keyboardHandler.ClearReceivedCalls();
 
-            // Act
-            _keyboardInput.Poll(keyboardStateKeyLost);
+        // Act
+        _keyboardInput.Poll(keyboardStateKeyLost);
 
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
 
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.BrowserBack, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_An_Older_Key_Is_Lost(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(oldKey);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            var keyboardStateKeyLost = new KeyboardState(newKey);
-
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is<Keys>(k => k == newKey),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-
-        [DataTestMethod]
-        [DataRow(Keys.X, Keys.A, false)]
-        [DataRow(Keys.F1, Keys.BrowserBack, false)]
-        [DataRow(Keys.D0, Keys.NumPad0, true)]
-        [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
-        [DataRow(Keys.X, Keys.RightShift, true)]
-        [DataRow(Keys.LeftControl, Keys.X, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_An_Older_Key_Is_Lost_And_New_Key_Pressed_Again(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(oldKey);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            var keyboardStateKeyLost = new KeyboardState(newKey);
-
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is<Keys>(k => k == oldKey),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Not_Should_Call_HandleKeyboardKeyRepeat_When_Same_Keyboard_State_Is_Present_After_First_Repeat_And_Before_First_RepeatFrequency(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency - 1);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_On_First_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(key),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyRepeat_After_First_RepeatFrequency_And_Before_Second_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency - 1);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_On_Second_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(key),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Call_HandleKeyboardKeysReleased_If_No_Keys_While_Repeating(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState();
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler.Received().HandleKeyboardKeysReleased();
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyLost_And_Not_Call_Other_Events_When_Keys_Released_And_Keys_Still_Down(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyLost(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Not_Call_Other_Events_When_Keys_Released_And_Keys_Still_Down_On_Second_Poll(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
-            _keyboardInput.Poll(keyboardStateReleased);
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Send_KeyDown_For_Only_New_Keys_When_Key_Lost_But_Some_Keys_Still_Down(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(key, Keys.B, Keys.C);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState(key, Keys.B);
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            var keyboardStateNewKeysDown = new KeyboardState(key, Keys.B, Keys.D, Keys.E);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateNewKeysDown);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, key, Keys.B, Keys.D, Keys.E)),
-                    Arg.Is(Keys.D),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, key, Keys.B, Keys.D, Keys.E)),
-                    Arg.Is(Keys.E),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(
-                    Arg.Any<Keys[]>(),
-                    Arg.Is(key),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .DidNotReceive()
-                .HandleKeyboardKeyDown(
-                    Arg.Any<Keys[]>(),
-                    Arg.Is(Keys.B),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.F1, false)]
-        [DataRow(Keys.NumPad0, true)]
-        [DataRow(Keys.LeftShift, true)]
-        [DataRow(Keys.RightShift, true)]
-        [DataRow(Keys.LeftAlt, true)]
-        [DataRow(Keys.RightAlt, true)]
-        [DataRow(Keys.LeftControl, true)]
-        [DataRow(Keys.RightControl, true)]
-        public void KeyboardInput_Should_Prioritise_KeyDown_State_Over_KeyLost_State_When_Keys_Lost_And_New_Key_Down_Happen_At_Same_Time(Keys key, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-
-            var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            var keyboardStateNewKeysDownWithOneKeyLost = new KeyboardState(Keys.A, Keys.D, Keys.E);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateNewKeysDownWithOneKeyLost);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.D, Keys.E)),
-                    Arg.Is(Keys.D),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.D, Keys.E)),
-                    Arg.Is(Keys.E),
-                    Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl)]
-        [DataRow(Keys.RightControl)]
-        [DataRow(Keys.LeftShift)]
-        [DataRow(Keys.RightShift)]
-        [DataRow(Keys.LeftAlt)]
-        [DataRow(Keys.RightAlt)]
-        public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Modifier_And_No_Other_Keys_Pressed(Keys modifierKey)
-        {
-            // Act
-            var keyboardStateDown = new KeyboardState(modifierKey);
-            _keyboardInput.Poll(keyboardStateDown);
-
-            var keyboardStateReleased = new KeyboardState();
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            _keyboardInput.Poll(keyboardStateDown);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardInput.Poll(keyboardStateDown);
-
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.X, true)]
-        [DataRow(Keys.LeftShift, false)]
-        [DataRow(Keys.LeftShift, true)]
-        public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged(Keys unmanagedKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-            _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
-
-            // Act
-            var keyboardStateDown = new KeyboardState(unmanagedKey);
-            _keyboardInput.Poll(keyboardStateDown);
-
-            var keyboardStateReleased = new KeyboardState();
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            _keyboardInput.Poll(keyboardStateDown);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardInput.Poll(keyboardStateDown);
-
-            _keyboardInput.Poll(keyboardStateReleased);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.X, true)]
-        [DataRow(Keys.LeftShift, false)]
-        [DataRow(Keys.LeftShift, true)]
-        public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged_When_A_Managed_Key_Is_Down(Keys unmanagedKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-            _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
-
-            var keyboardState = new KeyboardState(Keys.A);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateWithUnmanaged = new KeyboardState(Keys.A, unmanagedKey);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithUnmanaged);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.X, false)]
-        [DataRow(Keys.X, true)]
-        [DataRow(Keys.LeftShift, false)]
-        [DataRow(Keys.LeftShift, true)]
-        public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged_When_A_Managed_Key_Is_Lost(Keys unmanagedKey, bool treatModifiersAsKeys)
-        {
-            // Arrange
-            _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
-            _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
-
-            var keyboardState = new KeyboardState(Keys.A, Keys.B);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateLost = new KeyboardState(Keys.A);
-            _keyboardInput.Poll(keyboardStateLost);
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.BrowserBack, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_An_Older_Key_Is_Lost(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(oldKey);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        var keyboardStateKeyLost = new KeyboardState(newKey);
+
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is<Keys>(k => k == newKey),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+
+    [DataTestMethod]
+    [DataRow(Keys.X, Keys.A, false)]
+    [DataRow(Keys.F1, Keys.BrowserBack, false)]
+    [DataRow(Keys.D0, Keys.NumPad0, true)]
+    [DataRow(Keys.RightAlt, Keys.LeftShift, true)]
+    [DataRow(Keys.X, Keys.RightShift, true)]
+    [DataRow(Keys.LeftControl, Keys.X, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_When_An_Older_Key_Is_Lost_And_New_Key_Pressed_Again(Keys oldKey, Keys newKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(oldKey);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateExtraKey = new KeyboardState(oldKey, newKey);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        var keyboardStateKeyLost = new KeyboardState(newKey);
+
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is<Keys>(k => k == oldKey),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Not_Should_Call_HandleKeyboardKeyRepeat_When_Same_Keyboard_State_Is_Present_After_First_Repeat_And_Before_First_RepeatFrequency(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency - 1);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_On_First_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(key),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyRepeat_After_First_RepeatFrequency_And_Before_Second_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency - 1);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeyRepeat_On_Second_RepeatFrequency_When_Repeating(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatFrequency);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(key),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Call_HandleKeyboardKeysReleased_If_No_Keys_While_Repeating(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState();
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler.Received().HandleKeyboardKeysReleased();
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Not_Call_HandleKeyboardKeyLost_And_Not_Call_Other_Events_When_Keys_Released_And_Keys_Still_Down(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyLost(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.B)),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Not_Call_Other_Events_When_Keys_Released_And_Keys_Still_Down_On_Second_Poll(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
+        _keyboardInput.Poll(keyboardStateReleased);
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Send_KeyDown_For_Only_New_Keys_When_Key_Lost_But_Some_Keys_Still_Down(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(key, Keys.B, Keys.C);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState(key, Keys.B);
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        var keyboardStateNewKeysDown = new KeyboardState(key, Keys.B, Keys.D, Keys.E);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateNewKeysDown);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, key, Keys.B, Keys.D, Keys.E)),
+                Arg.Is(Keys.D),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, key, Keys.B, Keys.D, Keys.E)),
+                Arg.Is(Keys.E),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(
+                Arg.Any<Keys[]>(),
+                Arg.Is(key),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .DidNotReceive()
+            .HandleKeyboardKeyDown(
+                Arg.Any<Keys[]>(),
+                Arg.Is(Keys.B),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.F1, false)]
+    [DataRow(Keys.NumPad0, true)]
+    [DataRow(Keys.LeftShift, true)]
+    [DataRow(Keys.RightShift, true)]
+    [DataRow(Keys.LeftAlt, true)]
+    [DataRow(Keys.RightAlt, true)]
+    [DataRow(Keys.LeftControl, true)]
+    [DataRow(Keys.RightControl, true)]
+    public void KeyboardInput_Should_Prioritise_KeyDown_State_Over_KeyLost_State_When_Keys_Lost_And_New_Key_Down_Happen_At_Same_Time(Keys key, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+
+        var keyboardState = new KeyboardState(Keys.A, Keys.B, key);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateReleased = new KeyboardState(Keys.A, Keys.B);
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        var keyboardStateNewKeysDownWithOneKeyLost = new KeyboardState(Keys.A, Keys.D, Keys.E);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateNewKeysDownWithOneKeyLost);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.D, Keys.E)),
+                Arg.Is(Keys.D),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A, Keys.D, Keys.E)),
+                Arg.Is(Keys.E),
+                Arg.Is<KeyboardModifier>(k => k == KeyboardModifier.None)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl)]
+    [DataRow(Keys.RightControl)]
+    [DataRow(Keys.LeftShift)]
+    [DataRow(Keys.RightShift)]
+    [DataRow(Keys.LeftAlt)]
+    [DataRow(Keys.RightAlt)]
+    public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Modifier_And_No_Other_Keys_Pressed(Keys modifierKey)
+    {
+        // Act
+        var keyboardStateDown = new KeyboardState(modifierKey);
+        _keyboardInput.Poll(keyboardStateDown);
+
+        var keyboardStateReleased = new KeyboardState();
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        _keyboardInput.Poll(keyboardStateDown);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardInput.Poll(keyboardStateDown);
+
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.X, true)]
+    [DataRow(Keys.LeftShift, false)]
+    [DataRow(Keys.LeftShift, true)]
+    public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged(Keys unmanagedKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
+
+        // Act
+        var keyboardStateDown = new KeyboardState(unmanagedKey);
+        _keyboardInput.Poll(keyboardStateDown);
+
+        var keyboardStateReleased = new KeyboardState();
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        _keyboardInput.Poll(keyboardStateDown);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardInput.Poll(keyboardStateDown);
+
+        _keyboardInput.Poll(keyboardStateReleased);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.X, true)]
+    [DataRow(Keys.LeftShift, false)]
+    [DataRow(Keys.LeftShift, true)]
+    public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged_When_A_Managed_Key_Is_Down(Keys unmanagedKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
+
+        var keyboardState = new KeyboardState(Keys.A);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateWithUnmanaged = new KeyboardState(Keys.A, unmanagedKey);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithUnmanaged);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.X, false)]
+    [DataRow(Keys.X, true)]
+    [DataRow(Keys.LeftShift, false)]
+    [DataRow(Keys.LeftShift, true)]
+    public void KeyboardInput_Should_Do_Nothing_If_Key_Is_Unmananged_When_A_Managed_Key_Is_Lost(Keys unmanagedKey, bool treatModifiersAsKeys)
+    {
+        // Arrange
+        _keyboardInput.TreatModifiersAsKeys = treatModifiersAsKeys;
+        _keyboardInput.UnmanagedKeys.Add(unmanagedKey);
+
+        var keyboardState = new KeyboardState(Keys.A, Keys.B);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateLost = new KeyboardState(Keys.A);
+        _keyboardInput.Poll(keyboardStateLost);
             
-            var keyboardStateWithUnmanaged = new KeyboardState(Keys.A, unmanagedKey);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithUnmanaged);
-
-            var keyboardStateLostUnmanaged = new KeyboardState(Keys.A);
-
-            _keyboardInput.Poll(keyboardStateLostUnmanaged);
-
-            _keyboardInput.Poll(keyboardStateWithUnmanaged);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
-        [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(key, Keys.A);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.LeftControl, Keys.RightShift, Keys.LeftAlt, Keys.A);
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
-        [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_KeyboardModifier_Flags_Set_And_No_Focus_Key_When_Only_Modifiers_Change(Keys key, KeyboardModifier keyboardModifier)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateWithModifiers = new KeyboardState(key, Keys.A);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithModifiers);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.None),
-                    Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_Multiple_KeyboardModifier_Flags_Set_And_No_Focus_Key_When_Only_Modifiers_Change()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateWithModifiers = new KeyboardState(Keys.LeftControl, Keys.LeftShift, Keys.RightAlt, Keys.A);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithModifiers);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyDown(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is(Keys.None),
-                    Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
-        [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyRepeat_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A, key);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
-                );
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyRepeat_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardState);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
-                );
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
-        [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyLost_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A, key);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateExtraKey = new KeyboardState(Keys.A, Keys.B, key);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            var keyboardStateKeyLost = new KeyboardState(Keys.A, key);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyLost(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [TestMethod]
-        public void KeyboardInput_Should_Send_HandleKeyboardKeyLost_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
-            _keyboardInput.Poll(keyboardState);
-
-            var keyboardStateExtraKey = new KeyboardState(Keys.A, Keys.B, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
-
-            _keyboardInput.Poll(keyboardStateExtraKey);
-
-            var keyboardStateKeyLost = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateKeyLost);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyLost(
-                    Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
-                    Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl)]
-        [DataRow(Keys.RightControl)]
-        [DataRow(Keys.LeftShift)]
-        [DataRow(Keys.RightShift)]
-        [DataRow(Keys.LeftAlt)]
-        [DataRow(Keys.RightAlt)]
-        public void KeyboardInput_Should_Reset_Repeat_Timer_When_Modifiers_Change_While_Repeating(Keys key)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A);
-
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
-
-            var keyboardStateWithModifier = new KeyboardState(Keys.A, key);
-            _keyboardInput.Poll(keyboardStateWithModifier);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithModifier);
-
-            // Assert
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        [DataTestMethod]
-        [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
-        [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
-        [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
-        [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
-        public void KeyboardInput_Should_Begin_Repeating_Again_With_Modifier_After_Resetting_Repeat_Timer_When_Modifiers_Change(Keys key, KeyboardModifier keyboardModifier)
-        {
-            // Arrange
-            var keyboardState = new KeyboardState(Keys.A);
-
-            _keyboardInput.Poll(keyboardState);
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
-
-            var keyboardStateWithModifier = new KeyboardState(Keys.A, key);
-            _keyboardInput.Poll(keyboardStateWithModifier);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
-
-            _keyboardHandler.ClearReceivedCalls();
-
-            // Act
-            _keyboardInput.Poll(keyboardStateWithModifier);
-
-            // Assert
-            _keyboardHandler
-                .Received()
-                .HandleKeyboardKeyRepeat(
-                    Arg.Is(Keys.A),
-                    Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
-                );
-
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
-            _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
-        }
-
-        private bool AssertKeysMatch(Keys[] actual, params Keys[] expected)
-        {
-            var expectedInEnumOrder = expected
-                .OrderBy(x => x)
-                .ToArray();
-
-            CollectionAssert.AreEqual(expectedInEnumOrder, actual);
-            return true;
-        }
+        var keyboardStateWithUnmanaged = new KeyboardState(Keys.A, unmanagedKey);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithUnmanaged);
+
+        var keyboardStateLostUnmanaged = new KeyboardState(Keys.A);
+
+        _keyboardInput.Poll(keyboardStateLostUnmanaged);
+
+        _keyboardInput.Poll(keyboardStateWithUnmanaged);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
+    [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(key, Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.LeftControl, Keys.RightShift, Keys.LeftAlt, Keys.A);
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
+    [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_KeyboardModifier_Flags_Set_And_No_Focus_Key_When_Only_Modifiers_Change(Keys key, KeyboardModifier keyboardModifier)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateWithModifiers = new KeyboardState(key, Keys.A);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithModifiers);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.None),
+                Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyDown_With_Multiple_KeyboardModifier_Flags_Set_And_No_Focus_Key_When_Only_Modifiers_Change()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateWithModifiers = new KeyboardState(Keys.LeftControl, Keys.LeftShift, Keys.RightAlt, Keys.A);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithModifiers);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyDown(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is(Keys.None),
+                Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
+    [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyRepeat_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A, key);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
+            );
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyRepeat_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardState);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
+            );
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
+    [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyLost_With_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys(Keys key, KeyboardModifier keyboardModifier)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A, key);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateExtraKey = new KeyboardState(Keys.A, Keys.B, key);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        var keyboardStateKeyLost = new KeyboardState(Keys.A, key);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyLost(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [TestMethod]
+    public void KeyboardInput_Should_Send_HandleKeyboardKeyLost_With_Multiple_KeyboardModifier_Flags_Set_When_Not_Treating_Modifiers_As_Keys()
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
+        _keyboardInput.Poll(keyboardState);
+
+        var keyboardStateExtraKey = new KeyboardState(Keys.A, Keys.B, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
+
+        _keyboardInput.Poll(keyboardStateExtraKey);
+
+        var keyboardStateKeyLost = new KeyboardState(Keys.A, Keys.LeftControl, Keys.LeftShift, Keys.RightAlt);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateKeyLost);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyLost(
+                Arg.Is<Keys[]>(k => AssertKeysMatch(k, Keys.A)),
+                Arg.Is<KeyboardModifier>(k => k == (KeyboardModifier.Alt | KeyboardModifier.Shift | KeyboardModifier.Ctrl))
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl)]
+    [DataRow(Keys.RightControl)]
+    [DataRow(Keys.LeftShift)]
+    [DataRow(Keys.RightShift)]
+    [DataRow(Keys.LeftAlt)]
+    [DataRow(Keys.RightAlt)]
+    public void KeyboardInput_Should_Reset_Repeat_Timer_When_Modifiers_Change_While_Repeating(Keys key)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A);
+
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
+
+        var keyboardStateWithModifier = new KeyboardState(Keys.A, key);
+        _keyboardInput.Poll(keyboardStateWithModifier);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithModifier);
+
+        // Assert
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyRepeat(Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+
+    [DataTestMethod]
+    [DataRow(Keys.LeftControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.RightControl, KeyboardModifier.Ctrl)]
+    [DataRow(Keys.LeftShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.RightShift, KeyboardModifier.Shift)]
+    [DataRow(Keys.LeftAlt, KeyboardModifier.Alt)]
+    [DataRow(Keys.RightAlt, KeyboardModifier.Alt)]
+    public void KeyboardInput_Should_Begin_Repeating_Again_With_Modifier_After_Resetting_Repeat_Timer_When_Modifiers_Change(Keys key, KeyboardModifier keyboardModifier)
+    {
+        // Arrange
+        var keyboardState = new KeyboardState(Keys.A);
+
+        _keyboardInput.Poll(keyboardState);
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay - 1);
+
+        var keyboardStateWithModifier = new KeyboardState(Keys.A, key);
+        _keyboardInput.Poll(keyboardStateWithModifier);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(_keyboardInput.RepeatDelay);
+
+        _keyboardHandler.ClearReceivedCalls();
+
+        // Act
+        _keyboardInput.Poll(keyboardStateWithModifier);
+
+        // Assert
+        _keyboardHandler
+            .Received()
+            .HandleKeyboardKeyRepeat(
+                Arg.Is(Keys.A),
+                Arg.Is<KeyboardModifier>(k => k == keyboardModifier)
+            );
+
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyLost(Arg.Any<Keys[]>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeyDown(Arg.Any<Keys[]>(), Arg.Any<Keys>(), Arg.Any<KeyboardModifier>());
+        _keyboardHandler.DidNotReceive().HandleKeyboardKeysReleased();
+    }
+    
+    [TestMethod]
+    public void WaitForNeutralStateBeforeApplyingNewSubscriptions()
+    {
+        Assert.Fail();
+    } 
+
+    private bool AssertKeysMatch(Keys[] actual, params Keys[] expected)
+    {
+        var expectedInEnumOrder = expected
+            .OrderBy(x => x)
+            .ToArray();
+
+        CollectionAssert.AreEqual(expectedInEnumOrder, actual);
+        return true;
     }
 }

--- a/InputHandlers.Tests/MouseInputTests.cs
+++ b/InputHandlers.Tests/MouseInputTests.cs
@@ -10,1622 +10,1690 @@ using Microsoft.Xna.Framework.Input;
 using NSubstitute;
 using NSubstitute.ClearExtensions;
 
-namespace InputHandlers.Tests
+namespace InputHandlers.Tests;
+
+[TestClass]
+public class MouseInputTests
 {
-    [TestClass]
-    public class MouseInputTests
+    private MouseInput _mouseInput;
+    private IMouseHandler _mouseHandler;
+    private TestStopwatchProvider _testStopwatchProvider;
+
+    [TestInitialize]
+    public void Setup()
     {
-        private MouseInput _mouseInput;
-        private IMouseHandler _mouseHandler;
-        private TestStopwatchProvider _testStopwatchProvider;
+        _testStopwatchProvider = new TestStopwatchProvider();
+        _mouseHandler = Substitute.For<IMouseHandler>();
+        _mouseInput = new MouseInput(_testStopwatchProvider);
 
-        [TestInitialize]
-        public void Setup()
-        {
-            _testStopwatchProvider = new TestStopwatchProvider();
-            _mouseHandler = Substitute.For<IMouseHandler>();
-            _mouseInput = new MouseInput(_testStopwatchProvider);
+        _mouseInput.Subscribe(_mouseHandler);
+    }
 
-            _mouseInput.Subscribe(_mouseHandler);
-        }
+    [TestMethod]
+    public void MouseInput_Should_Call_No_Handlers_When_Polling_With_Blank_MouseState()
+    {
+        // Arrange
+        var mouseState = new MouseState();
 
-        [TestMethod]
-        public void MouseInput_Should_Call_No_Handlers_When_Polling_With_Blank_MouseState()
-        {
-            // Arrange
-            var mouseState = new MouseState();
+        // Act
+        _mouseInput.Poll(mouseState);
 
-            // Act
-            _mouseInput.Poll(mouseState);
+        // Assert
+        _mouseHandler.DidNotReceive().HandleMouseScrollWheelMove(Arg.Any<MouseState>(), Arg.Any<int>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
 
-            // Assert
-            _mouseHandler.DidNotReceive().HandleMouseScrollWheelMove(Arg.Any<MouseState>(), Arg.Any<int>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
+    [TestMethod]
+    public void MouseInput_Should_Increment_UpdateNumber_On_Poll()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
 
-        [TestMethod]
-        public void MouseInput_Should_Increment_UpdateNumber_On_Poll()
-        {
-            // Arrange
-            var secondMouseHandler = Substitute.For<IMouseHandler>();
+        _mouseInput.Subscribe(secondMouseHandler);
 
-            _mouseInput.Subscribe(secondMouseHandler);
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
 
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
+        // Act
+        _mouseInput.Poll(mouseState);
 
-            // Act
-            _mouseInput.Poll(mouseState);
+        // Assert
+        Assert.AreEqual(1, _mouseInput.UpdateNumber);
 
-            // Assert
-            Assert.AreEqual(1, _mouseInput.UpdateNumber);
+        // Act - poll 2
+        _mouseInput.Poll(mouseState);
 
-            // Act - poll 2
-            _mouseInput.Poll(mouseState);
+        // Assert = poll 2
+        Assert.AreEqual(2, _mouseInput.UpdateNumber);
+    }
 
-            // Assert = poll 2
-            Assert.AreEqual(2, _mouseInput.UpdateNumber);
-        }
+    [TestMethod]
+    public void MouseInput_Should_Reset_To_Stationary_State_And_Set_UpdateNumber_To_Zero_When_Resetting()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
 
-        [TestMethod]
-        public void MouseInput_Should_Reset_To_Stationary_State_And_Set_UpdateNumber_To_Zero_When_Resetting()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
+        _mouseInput.Poll(mouseState);
 
-            _mouseInput.Poll(mouseState);
+        _mouseHandler.ClearReceivedCalls();
 
-            _mouseHandler.ClearReceivedCalls();
+        // Act
+        _mouseInput.Reset();
 
-            // Act
-            _mouseInput.Reset();
+        // Assert
+        Assert.AreEqual(0, _mouseInput.UpdateNumber);
 
-            // Assert
-            Assert.AreEqual(0, _mouseInput.UpdateNumber);
+        // Act - poll again with mouse released, state is stationary and so no mouse up will occur
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
 
-            // Act - poll again with mouse released, state is stationary and so no mouse up will occur
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
+        _mouseInput.Poll(mouseStateReleased);
 
-            _mouseInput.Poll(mouseStateReleased);
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
 
-            _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
+    [TestMethod]
+    public void MouseInput_Should_Broadcast_To_Both_Handlers_When_MouseInput_Has_Two_Subscriptions()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
 
-        [TestMethod]
-        public void MouseInput_Should_Broadcast_To_Both_Handlers_When_MouseInput_Has_Two_Subscriptions()
-        {
-            // Arrange
-            var secondMouseHandler = Substitute.For<IMouseHandler>();
+        _mouseInput.Subscribe(secondMouseHandler);
 
-            _mouseInput.Subscribe(secondMouseHandler);
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
 
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
+        // Act
+        _mouseInput.Poll(mouseState);
 
-            // Act
-            _mouseInput.Poll(mouseState);
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+        secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+    }
 
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
-            secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
-        }
+    [TestMethod]
+    public void MouseInput_Should_Subscribe_And_Unsubscribe_Correctly()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
 
-        [TestMethod]
-        public void MouseInput_Should_Subscribe_And_Unsubscribe_Correctly()
-        {
-            // Arrange
-            var secondMouseHandler = Substitute.For<IMouseHandler>();
-
-            _mouseInput.Subscribe(secondMouseHandler);
-            _mouseInput.Unsubscribe(_mouseHandler);
+        _mouseInput.Subscribe(secondMouseHandler);
+        _mouseInput.Unsubscribe(_mouseHandler);
             
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
 
-            // Act
-            _mouseInput.Poll(mouseState);
+        // Act
+        _mouseInput.Poll(mouseState);
 
-            // Assert
-            _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-            secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
-        }
+        // Assert
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+    }
+    
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    public void Remove_Subscription_When_Same_Handler_Is_Also_In_Pending_Add_And_Remove_Timestamp_Is_Greater_Or_Equal_Then_Subscription_Is_Removed(int advanceTime)
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
 
-        [TestMethod]
-        public void MouseInput_Can_Subscribe_While_Within_Handler_Of_Another_Subscription()
-        {
-            // Arrange
-            var secondMouseHandler = Substitute.For<IMouseHandler>();
-
-            var mouseStateDown = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseHandler
-                .When(k => k.HandleLeftMouseDown(Arg.Is(mouseStateDown)))
-                .Do(ci => _mouseInput.Subscribe(secondMouseHandler));
-
-            // Act
-            _mouseInput.Poll(mouseStateDown);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
-            secondMouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-
-            // Arrange - second handler should now be subscribed
-            _mouseHandler.ClearSubstitute();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
-            secondMouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
-        }
-
-        [TestMethod]
-        public void MouseInput_Can_Unsubscribe_While_Within_Handler_Of_Another_Subscription()
-        {
-            // Arrange
-            var secondMouseHandler = Substitute.For<IMouseHandler>();
-            _mouseInput.Subscribe(secondMouseHandler);
-
-            var mouseStateDown = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseHandler
-                .When(k => k.HandleLeftMouseDown(Arg.Is(mouseStateDown)))
-                .Do(ci => _mouseInput.Unsubscribe(secondMouseHandler));
-
-            // Act
-            _mouseInput.Poll(mouseStateDown);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
-            secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
-
-            // Arrange - second handler should now be subscribed
-            _mouseHandler.ClearSubstitute();
-            secondMouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
-            secondMouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Ignore_Second_Subscription_Of_Same_Handler()
-        {
-            // Arrange
-            _mouseInput.Subscribe(_mouseHandler);
-
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            Assert.AreEqual(1, _mouseHandler.ReceivedCalls().Count());
-
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMouseMoving_When_Mouse_Changes_Position()
-        {
-            // Arrange
-            var mouseStateOrigin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStateOrigin);
-
-            var mouseStateMoving = new MouseState(
-                1,
-                1,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateMoving);
+        _mouseInput.Unsubscribe(_mouseHandler);
+        _mouseInput.Subscribe(secondMouseHandler);
+        _testStopwatchProvider.AdvanceByMilliseconds(advanceTime);
+        _mouseInput.Unsubscribe(secondMouseHandler);
             
-            // Assert
-            _mouseHandler.Received().HandleMouseMoving(Arg.Is(mouseStateMoving), Arg.Is(mouseStateOrigin));
-        }
-
-        [DataTestMethod]
-        [DataRow(-1)]
-        [DataRow(1)]
-        [DataRow(-2)]
-        [DataRow(2)]
-        public void MouseInput_Should_Call_HandleMouseScrollWheelMove_When_Scrollwheel_Moves(int scrollWheelMoveAmount)
-        {
-            // Arrange
-            var mouseStateOrigin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStateOrigin);
-
-            var mouseStateMouseWheelMove = new MouseState(
-                0,
-                0,
-                scrollWheelMoveAmount,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateMouseWheelMove);
-
-            // Assert
-            _mouseHandler.Received().HandleMouseScrollWheelMove(Arg.Is(mouseStateMouseWheelMove), scrollWheelMoveAmount);
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleLeftMouseDown_When_Left_Is_Pressed()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Do_Nothing_When_Left_Is_Pressed_When_Left_Button_Disabled()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.IsLeftButtonEnabled = false;
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleLeftMouseClick_And_Up_When_Left_Released()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleLeftMouseClick_And_Up_While_Within_Tolerance()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                _mouseInput.DragVariance,
-                _mouseInput.DragVariance,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateWithinDragDropToleranceMax = new MouseState(
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
-
-            var mouseStateWithinDragDropToleranceMin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleLeftMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Not_Call_HandleLeftMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateSecondClick));
-
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [DataTestMethod]
-        [DataRow(-1)]
-        [DataRow(1)]
-        public void MouseInput_Should_Call_HandleLeftMouseDragging_When_Dragging_With_Left_Down(int varianceMultiplier)
-        {
-            // Arrange
-            var startingPosition = _mouseInput.DragVariance * 2;
-
-            var mouseStatePressedOrigin = new MouseState(
-                startingPosition,
-                startingPosition,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateDragging = new MouseState(
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateDragging);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleLeftMouseDragDone_And_Left_Up_When_Releasing_Left_After_Drag()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-
-            var mouseStateDragging = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            _mouseInput.Poll(mouseStateDragging);
-
-            var mouseStateReleased = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleLeftMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleRightMouseDown_When_Right_Is_Pressed()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseDown(Arg.Is(mouseState));
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Do_Nothing_When_Right_Is_Pressed_When_Right_Button_Disabled()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.IsRightButtonEnabled = false;
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleRightMouseClick_And_Up_When_Right_Released()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleRightMouseClick_And_Up_While_Within_Tolerance()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                _mouseInput.DragVariance,
-                _mouseInput.DragVariance,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateWithinDragDropToleranceMax = new MouseState(
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
-
-            var mouseStateWithinDragDropToleranceMin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleRightMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Not_Call_HandleRightMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseDown(Arg.Is(mouseStateSecondClick));
-
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [DataTestMethod]
-        [DataRow(-1)]
-        [DataRow(1)]
-        public void MouseInput_Should_Call_HandleRightMouseDragging_When_Dragging_With_Right_Down(int varianceMultiplier)
-        {
-            // Arrange
-            var startingPosition = _mouseInput.DragVariance * 2;
-
-            var mouseStatePressedOrigin = new MouseState(
-                startingPosition,
-                startingPosition,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released);
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateDragging = new MouseState(
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateDragging);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleRightMouseDragDone_And_Right_Up_When_Releasing_Right_After_Drag()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-
-            var mouseStateDragging = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            _mouseInput.Poll(mouseStateDragging);
-
-            var mouseStateReleased = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleRightMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMiddleMouseDown_When_Middle_Is_Pressed()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseDown(Arg.Is(mouseState));
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Do_Nothing_When_Middle_Is_Pressed_When_Middle_Button_Disabled()
-        {
-            // Arrange
-            var mouseState = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.IsMiddleButtonEnabled = false;
-
-            // Act
-            _mouseInput.Poll(mouseState);
-
-            // Assert
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMiddleMouseClick_And_Up_When_Middle_Released()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMiddleMouseClick_And_Up_While_Within_Tolerance()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                _mouseInput.DragVariance,
-                _mouseInput.DragVariance,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateWithinDragDropToleranceMax = new MouseState(
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                _mouseInput.DragVariance + _mouseInput.DragVariance,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
-
-            var mouseStateWithinDragDropToleranceMin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMiddleMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
-            _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Not_Call_HandleMiddleMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
-        {
-            // Arrange
-            var mouseStatePressed = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressed);
-
-            var mouseStateFirstRelease = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateFirstRelease);
-
-            var mouseStateSecondClick = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateSecondClick);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseDown(Arg.Is(mouseStateSecondClick));
-
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-
-            // Act - Releasing
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateReleased = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert - Releasing
-            _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [DataTestMethod]
-        [DataRow(-1)]
-        [DataRow(1)]
-        public void MouseInput_Should_Call_HandleMiddleMouseDragging_When_Dragging_With_Middle_Down(int varianceMultiplier)
-        {
-            // Arrange
-            var startingPosition = _mouseInput.DragVariance * 2;
-
-            var mouseStatePressedOrigin = new MouseState(
-                startingPosition,
-                startingPosition,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-            _mouseHandler.ClearReceivedCalls();
-
-            var mouseStateDragging = new MouseState(
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            // Act
-            _mouseInput.Poll(mouseStateDragging);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-            _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
-
-        [TestMethod]
-        public void MouseInput_Should_Call_HandleMiddleMouseDragDone_And_Middle_Up_When_Releasing_Middle_After_Drag()
-        {
-            // Arrange
-            var mouseStatePressedOrigin = new MouseState(
-                0,
-                0,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _mouseInput.Poll(mouseStatePressedOrigin);
-
-            var mouseStateDragging = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Released,
-                ButtonState.Pressed,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-
-            _mouseInput.Poll(mouseStateDragging);
-
-            var mouseStateReleased = new MouseState(
-                _mouseInput.DragVariance + 1,
-                _mouseInput.DragVariance + 1,
-                0,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released,
-                ButtonState.Released
-            );
-
-            _testStopwatchProvider.AdvanceByMilliseconds(1);
-            _mouseHandler.ClearReceivedCalls();
-
-            // Act
-            _mouseInput.Poll(mouseStateReleased);
-
-            // Assert
-            _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.Received().HandleMiddleMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
-            _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
-        }
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        secondMouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+    }
+    
+    [TestMethod]
+    public void Remove_Subscription_When_Same_Handler_Is_Also_In_Pending_Add_And_Remove_Timestamp_Is_Less_Then_Subscription_Is_Added()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
+
+        _mouseInput.Unsubscribe(_mouseHandler);
+        _mouseInput.Subscribe(secondMouseHandler);
+        _mouseInput.Unsubscribe(secondMouseHandler);
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Subscribe(secondMouseHandler);
+            
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+    }  
+
+    [TestMethod]
+    public void MouseInput_Can_Subscribe_While_Within_Handler_Of_Another_Subscription()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
+
+        var mouseStateDown = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseHandler
+            .When(k => k.HandleLeftMouseDown(Arg.Is(mouseStateDown)))
+            .Do(ci => _mouseInput.Subscribe(secondMouseHandler));
+
+        // Act
+        _mouseInput.Poll(mouseStateDown);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
+        secondMouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+
+        // Arrange - second handler should now be subscribed
+        _mouseHandler.ClearSubstitute();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
+        secondMouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
+    }
+
+    [TestMethod]
+    public void MouseInput_Can_Unsubscribe_While_Within_Handler_Of_Another_Subscription()
+    {
+        // Arrange
+        var secondMouseHandler = Substitute.For<IMouseHandler>();
+        _mouseInput.Subscribe(secondMouseHandler);
+
+        var mouseStateDown = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseHandler
+            .When(k => k.HandleLeftMouseDown(Arg.Is(mouseStateDown)))
+            .Do(ci => _mouseInput.Unsubscribe(secondMouseHandler));
+
+        // Act
+        _mouseInput.Poll(mouseStateDown);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
+        secondMouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateDown));
+
+        // Arrange - second handler should now be subscribed
+        _mouseHandler.ClearSubstitute();
+        secondMouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateDown));
+        secondMouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Ignore_Second_Subscription_Of_Same_Handler()
+    {
+        // Arrange
+        _mouseInput.Subscribe(_mouseHandler);
+
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        Assert.AreEqual(1, _mouseHandler.ReceivedCalls().Count());
+
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMouseMoving_When_Mouse_Changes_Position()
+    {
+        // Arrange
+        var mouseStateOrigin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStateOrigin);
+
+        var mouseStateMoving = new MouseState(
+            1,
+            1,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateMoving);
+            
+        // Assert
+        _mouseHandler.Received().HandleMouseMoving(Arg.Is(mouseStateMoving), Arg.Is(mouseStateOrigin));
+    }
+
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    [DataRow(-2)]
+    [DataRow(2)]
+    public void MouseInput_Should_Call_HandleMouseScrollWheelMove_When_Scrollwheel_Moves(int scrollWheelMoveAmount)
+    {
+        // Arrange
+        var mouseStateOrigin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStateOrigin);
+
+        var mouseStateMouseWheelMove = new MouseState(
+            0,
+            0,
+            scrollWheelMoveAmount,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateMouseWheelMove);
+
+        // Assert
+        _mouseHandler.Received().HandleMouseScrollWheelMove(Arg.Is(mouseStateMouseWheelMove), scrollWheelMoveAmount);
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleLeftMouseDown_When_Left_Is_Pressed()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseState));
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Do_Nothing_When_Left_Is_Pressed_When_Left_Button_Disabled()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.IsLeftButtonEnabled = false;
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleLeftMouseClick_And_Up_When_Left_Released()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleLeftMouseClick_And_Up_While_Within_Tolerance()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            _mouseInput.DragVariance,
+            _mouseInput.DragVariance,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateWithinDragDropToleranceMax = new MouseState(
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
+
+        var mouseStateWithinDragDropToleranceMin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleLeftMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleLeftMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateSecondClick));
+
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    public void MouseInput_Should_Call_HandleLeftMouseDragging_When_Dragging_With_Left_Down(int varianceMultiplier)
+    {
+        // Arrange
+        var startingPosition = _mouseInput.DragVariance * 2;
+
+        var mouseStatePressedOrigin = new MouseState(
+            startingPosition,
+            startingPosition,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateDragging = new MouseState(
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateDragging);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleLeftMouseDragDone_And_Left_Up_When_Releasing_Left_After_Drag()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+
+        var mouseStateDragging = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        _mouseInput.Poll(mouseStateDragging);
+
+        var mouseStateReleased = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleLeftMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleRightMouseDown_When_Right_Is_Pressed()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseDown(Arg.Is(mouseState));
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Do_Nothing_When_Right_Is_Pressed_When_Right_Button_Disabled()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.IsRightButtonEnabled = false;
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleRightMouseClick_And_Up_When_Right_Released()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleRightMouseClick_And_Up_While_Within_Tolerance()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            _mouseInput.DragVariance,
+            _mouseInput.DragVariance,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateWithinDragDropToleranceMax = new MouseState(
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
+
+        var mouseStateWithinDragDropToleranceMin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleRightMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleRightMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseDown(Arg.Is(mouseStateSecondClick));
+
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleRightMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    public void MouseInput_Should_Call_HandleRightMouseDragging_When_Dragging_With_Right_Down(int varianceMultiplier)
+    {
+        // Arrange
+        var startingPosition = _mouseInput.DragVariance * 2;
+
+        var mouseStatePressedOrigin = new MouseState(
+            startingPosition,
+            startingPosition,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateDragging = new MouseState(
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateDragging);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleRightMouseDragDone_And_Right_Up_When_Releasing_Right_After_Drag()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+
+        var mouseStateDragging = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        _mouseInput.Poll(mouseStateDragging);
+
+        var mouseStateReleased = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleRightMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMiddleMouseDown_When_Middle_Is_Pressed()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseDown(Arg.Is(mouseState));
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Do_Nothing_When_Middle_Is_Pressed_When_Middle_Button_Disabled()
+    {
+        // Arrange
+        var mouseState = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.IsMiddleButtonEnabled = false;
+
+        // Act
+        _mouseInput.Poll(mouseState);
+
+        // Assert
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMiddleMouseClick_And_Up_When_Middle_Released()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMiddleMouseClick_And_Up_While_Within_Tolerance()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            _mouseInput.DragVariance,
+            _mouseInput.DragVariance,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateWithinDragDropToleranceMax = new MouseState(
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            _mouseInput.DragVariance + _mouseInput.DragVariance,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMax);
+
+        var mouseStateWithinDragDropToleranceMin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateWithinDragDropToleranceMin);
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMiddleMouseDoubleClick_Immediately_On_Second_Click_And_Suppress_MouseUp()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseDoubleClick(Arg.Is(mouseStateSecondClick), Arg.Is(mouseStatePressed));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleMiddleMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay + 1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseDown(Arg.Is(mouseStateSecondClick));
+
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDragDone(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDragging(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    public void MouseInput_Should_Call_HandleMiddleMouseDragging_When_Dragging_With_Middle_Down(int varianceMultiplier)
+    {
+        // Arrange
+        var startingPosition = _mouseInput.DragVariance * 2;
+
+        var mouseStatePressedOrigin = new MouseState(
+            startingPosition,
+            startingPosition,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateDragging = new MouseState(
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            startingPosition + (_mouseInput.DragVariance + 1) * varianceMultiplier,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        // Act
+        _mouseInput.Poll(mouseStateDragging);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseDragging(Arg.Is(mouseStateDragging), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleMouseMoving(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+
+    [TestMethod]
+    public void MouseInput_Should_Call_HandleMiddleMouseDragDone_And_Middle_Up_When_Releasing_Middle_After_Drag()
+    {
+        // Arrange
+        var mouseStatePressedOrigin = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressedOrigin);
+
+        var mouseStateDragging = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+
+        _mouseInput.Poll(mouseStateDragging);
+
+        var mouseStateReleased = new MouseState(
+            _mouseInput.DragVariance + 1,
+            _mouseInput.DragVariance + 1,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.Received().HandleMiddleMouseDragDone(Arg.Is(mouseStateReleased), Arg.Is(mouseStatePressedOrigin));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+    
+    [TestMethod]
+    public void WaitForNeutralStateBeforeApplyingNewSubscriptions()
+    {
+        Assert.Fail();
     }
 }

--- a/InputHandlers.Tests/MouseInputTests.cs
+++ b/InputHandlers.Tests/MouseInputTests.cs
@@ -687,6 +687,85 @@ public class MouseInputTests
         _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
         _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
     }
+    
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleLeftMouseDoubleClick_If_ResetDoubleClickDetection_Is_Called()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.ResetDoubleClickDetection();
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleLeftMouseDown(Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleLeftMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleLeftMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.Received().HandleLeftMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleLeftMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+    }
 
     [TestMethod]
     public void MouseInput_Should_Not_Call_HandleLeftMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
@@ -1097,6 +1176,83 @@ public class MouseInputTests
         _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
         _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
         _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+    }
+    
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleRightMouseDoubleClick_If_ResetDoubleClickDetection_Is_Called()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released);
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.ResetDoubleClickDetection();
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleRightMouseDown(Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleRightMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleRightMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.Received().HandleRightMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleRightMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
     }
 
     [TestMethod]
@@ -1510,6 +1666,85 @@ public class MouseInputTests
         _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
         _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
     }
+    
+    [TestMethod]
+    public void MouseInput_Should_Not_Call_HandleMiddleMouseDoubleClick_If_ResetDoubleClickDetection_Is_Called()
+    {
+        // Arrange
+        var mouseStatePressed = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _mouseInput.Poll(mouseStatePressed);
+
+        var mouseStateFirstRelease = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateFirstRelease);
+
+        var mouseStateSecondClick = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Pressed,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.Elapsed = new TimeSpan(0, 0, 0, 0, _mouseInput.DoubleClickDetectionTimeDelay);
+        _mouseHandler.ClearReceivedCalls();
+
+        // Act
+        _mouseInput.ResetDoubleClickDetection();
+        _mouseInput.Poll(mouseStateSecondClick);
+
+        // Assert
+        _mouseHandler.Received().HandleMiddleMouseDown(Arg.Is(mouseStateSecondClick));
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseUp(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+
+        // Act - Releasing
+        _mouseHandler.ClearReceivedCalls();
+
+        var mouseStateReleased = new MouseState(
+            0,
+            0,
+            0,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released,
+            ButtonState.Released
+        );
+
+        _testStopwatchProvider.AdvanceByMilliseconds(1);
+        _mouseInput.Poll(mouseStateReleased);
+
+        // Assert - Releasing
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDoubleClick(Arg.Any<MouseState>(), Arg.Any<MouseState>());
+        _mouseHandler.DidNotReceive().HandleMiddleMouseDown(Arg.Any<MouseState>());
+        _mouseHandler.Received().HandleMiddleMouseClick(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+        _mouseHandler.Received().HandleMiddleMouseUp(Arg.Is(mouseStateReleased), Arg.Is(mouseStateSecondClick));
+    }
 
     [TestMethod]
     public void MouseInput_Should_Not_Call_HandleMiddleMouseDoubleClick_If_DoubleClickDetection_Time_Has_Passed()
@@ -1816,8 +2051,9 @@ public class MouseInputTests
         
         _mouseInput.Poll(mouseStateNeutral);
         
-        //need to aadvance time to prevent double click event
-        this._testStopwatchProvider.AdvanceByMilliseconds(3000);
+        // The WaitForNeutralStateBeforeApplyingNewSubscriptions feature does not automatically reset state related to detecting double clicks. 
+        // Handlers must call ResetDoubleClickDetection manually if they need to suppress double click events going to another handler.
+        _mouseInput.ResetDoubleClickDetection();
 
         // Act
         _mouseInput.Poll(mouseStateLeftPressed);

--- a/InputHandlers.Tests/TestStopwatchProvider.cs
+++ b/InputHandlers.Tests/TestStopwatchProvider.cs
@@ -1,37 +1,36 @@
 ﻿using System;
 
-namespace InputHandlers.Tests
+namespace InputHandlers.Tests;
+
+public class TestStopwatchProvider : IStopwatchProvider
 {
-    public class TestStopwatchProvider : IStopwatchProvider
+    public TestStopwatchProvider()
     {
-        public TestStopwatchProvider()
-        {
-            Reset();
-        }
+        Reset();
+    }
 
-        public void Start()
-        {
-            IsRunning = true;
-        }
+    public void Start()
+    {
+        IsRunning = true;
+    }
 
-        public void Stop()
-        {
-            IsRunning = false;
-        }
+    public void Stop()
+    {
+        IsRunning = false;
+    }
 
-        public void Reset()
-        {
-            Stop();
-            Elapsed = TimeSpan.Zero;
-        }
+    public void Reset()
+    {
+        Stop();
+        Elapsed = TimeSpan.Zero;
+    }
 
-        public bool IsRunning { get; set; }
+    public bool IsRunning { get; set; }
 
-        public TimeSpan Elapsed { get; set; }
+    public TimeSpan Elapsed { get; set; }
 
-        public void AdvanceByMilliseconds(int milliseconds)
-        {
-            Elapsed = Elapsed.Add(new TimeSpan(0, 0, 0, 0, milliseconds));
-        }
+    public void AdvanceByMilliseconds(int milliseconds)
+    {
+        Elapsed = Elapsed.Add(new TimeSpan(0, 0, 0, 0, milliseconds));
     }
 }

--- a/InputHandlers/IKeyboardHandler.cs
+++ b/InputHandlers/IKeyboardHandler.cs
@@ -1,46 +1,43 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using InputHandlers.Keyboard;
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers;
+
+public interface IKeyboardHandler
 {
-    public interface IKeyboardHandler
-    {
-        /// <summary>
-        /// Handle a key down event.  A unique call is made to this event every single time an individual key is pressed.  The
-        /// 'keyInFocus' key of each call is retrievable through the keyInFocus parameter.
-        /// </summary>
-        /// <param name="keysDown">
-        /// The entire set of keys currently held down on the keyboard (please note that number of keys
-        /// detectable is subject to hardware limitations on your keyboard)
-        /// </param>
-        /// <param name="keyInFocus">The key that was pressed to create this event.</param>
-        /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
-        void HandleKeyboardKeyDown(Keys[] keysDown, Keys keyInFocus, KeyboardModifier keyboardModifier);
+    /// <summary>
+    /// Handle a key down event.  A unique call is made to this event every single time an individual key is pressed.  The
+    /// 'keyInFocus' key of each call is retrievable through the keyInFocus parameter.
+    /// </summary>
+    /// <param name="keysDown">
+    /// The entire set of keys currently held down on the keyboard (please note that number of keys
+    /// detectable is subject to hardware limitations on your keyboard)
+    /// </param>
+    /// <param name="keyInFocus">The key that was pressed to create this event.</param>
+    /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
+    void HandleKeyboardKeyDown(Keys[] keysDown, Keys keyInFocus, KeyboardModifier keyboardModifier);
 
-        /// <summary>
-        /// Handle a key lost event.  This occurs when multiple keys are held down and then a key is released but some keys
-        /// are still being held.
-        /// </summary>
-        /// <param name="keysDown">
-        /// The entire set of keys currently held down on the keyboard (please note that number of keys
-        /// detectable is subject to hardware limitations on your keyboard)
-        /// </param>
-        /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
-        void HandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier);
+    /// <summary>
+    /// Handle a key lost event.  This occurs when multiple keys are held down and then a key is released but some keys
+    /// are still being held.
+    /// </summary>
+    /// <param name="keysDown">
+    /// The entire set of keys currently held down on the keyboard (please note that number of keys
+    /// detectable is subject to hardware limitations on your keyboard)
+    /// </param>
+    /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
+    void HandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier);
 
-        /// <summary>
-        /// Handle a key repeat event.  Once the repeat delay threshold is exceeded when the same key(s) are held down for long
-        /// enough then the program will start sending key repeat events on every update.
-        /// </summary>
-        /// <param name="repeatingKey">the key that is to be repeated.  This is always the last key held down.</param>
-        /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
-        void HandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier);
+    /// <summary>
+    /// Handle a key repeat event.  Once the repeat delay threshold is exceeded when the same key(s) are held down for long
+    /// enough then the program will start sending key repeat events on every update.
+    /// </summary>
+    /// <param name="repeatingKey">the key that is to be repeated.  This is always the last key held down.</param>
+    /// <param name="keyboardModifier">a bit field holding control, alt and shift key status</param>
+    void HandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier);
 
-        /// <summary>
-        /// Handle the situation where all keys have been released.
-        /// </summary>
-        void HandleKeyboardKeysReleased();
-    }
+    /// <summary>
+    /// Handle the situation where all keys have been released.
+    /// </summary>
+    void HandleKeyboardKeysReleased();
 }

--- a/InputHandlers/IKeyboardInput.cs
+++ b/InputHandlers/IKeyboardInput.cs
@@ -1,49 +1,52 @@
 using System.Collections.Generic;
-
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers;
+
+public interface IKeyboardInput
 {
-    public interface IKeyboardInput
-    {
-        KeyboardState OldKeyboardState { get; }
-        KeyboardState CurrentKeyboardState { get; }
-        IList<Keys> UnmanagedKeys { get; }
-        IStopwatchProvider StopwatchProvider { get; }
+    KeyboardState OldKeyboardState { get; }
+    KeyboardState CurrentKeyboardState { get; }
+    IList<Keys> UnmanagedKeys { get; }
+    IStopwatchProvider StopwatchProvider { get; }
 
-        /// <summary>
-        /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
-        /// </summary>
-        int UpdateNumber { get; }
+    /// <summary>
+    /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
+    /// </summary>
+    int UpdateNumber { get; }
 
-        /// <summary>
-        /// Sets time delay in milliseconds to wait for a key being held down until it repeats
-        /// </summary>
-        int RepeatDelay { get; set; }
+    /// <summary>
+    /// Sets time delay in milliseconds to wait for a key being held down until it repeats
+    /// </summary>
+    int RepeatDelay { get; set; }
 
-        /// <summary>
-        /// Set time in milliseconds between key repeats once it has started to repeat
-        /// </summary>
-        int RepeatFrequency { get; set; }
+    /// <summary>
+    /// Set time in milliseconds between key repeats once it has started to repeat
+    /// </summary>
+    int RepeatFrequency { get; set; }
 
-        /// <summary>
-        /// Whether to treat modifier keys (ctrl/alt/shift) as actual keys
-        /// </summary>
-        bool TreatModifiersAsKeys { get; set; }
+    /// <summary>
+    /// Whether to treat modifier keys (ctrl/alt/shift) as actual keys
+    /// </summary>
+    bool TreatModifiersAsKeys { get; set; }
+        
+    /// <summary>
+    /// Whether to wait for a neutral keyboard state before applying new pending subscriptions. Old subscriptions are still removed immediately. Defaults to False.
+    /// </summary>
+    bool WaitForNeutralStateBeforeApplyingNewSubscriptions { get; set; }
 
-        bool IsRepeatEnabled { get; set; }
-        void Subscribe(IKeyboardHandler keyboardHandler);
-        void Unsubscribe(IKeyboardHandler keyboardHandler);
+    bool IsRepeatEnabled { get; set; }
+    void Subscribe(IKeyboardHandler keyboardHandler);
+    void Unsubscribe(IKeyboardHandler keyboardHandler);
 
-        /// <summary>
-        /// Poll the keyboard for updates.
-        /// </summary>
-        /// <param name="keyboardState">a keyboard state.  You should use the XNA input function, Keyboard.GetState(), as this parameter.</param>
-        void Poll(KeyboardState keyboardState);
+    /// <summary>
+    /// Poll the keyboard for updates.
+    /// </summary>
+    /// <param name="keyboardState">a keyboard state.  You should use the XNA input function, Keyboard.GetState(), as this parameter.</param>
+    void Poll(KeyboardState keyboardState);
 
-        /// <summary>
-        /// Reset to unpressed state.  You may wish to call this when, for example, switching interface screens.
-        /// </summary>
-        void Reset();
-    }
+    /// <summary>
+    /// Reset to unpressed state.  You may wish to call this when, for example, switching interface screens.
+    /// </summary>
+    void Reset();
 }

--- a/InputHandlers/IMouseHandler.cs
+++ b/InputHandlers/IMouseHandler.cs
@@ -1,186 +1,182 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Mouse
+namespace InputHandlers;
+
+public interface IMouseHandler
 {
-    public interface IMouseHandler
-    {
-        /// <summary>
-        /// Handle mouse wheel movement
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="difference">
-        /// Direction and magnitude the user moved the wheel since last update.  Positive is down, negative is up
-        /// </param>
-        void HandleMouseScrollWheelMove(MouseState mouseState, int difference);
+    /// <summary>
+    /// Handle mouse wheel movement
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="difference">
+    /// Direction and magnitude the user moved the wheel since last update.  Positive is down, negative is up
+    /// </param>
+    void HandleMouseScrollWheelMove(MouseState mouseState, int difference);
 
-        /// <summary>
-        /// Handle mouse movement when neither left or right mouse buttons are down.  This event is continuously sent every
-        /// update while the mouse moves.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">Previous state of mouse contining position from last poll</param>
-        void HandleMouseMoving(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle mouse movement when neither left or right mouse buttons are down.  This event is continuously sent every
+    /// update while the mouse moves.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">Previous state of mouse contining position from last poll</param>
+    void HandleMouseMoving(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleLeftMouseClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleLeftMouseClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle left mouse double click.  Unlike a left mouse click, no mouse up event is sent for this action - this is
-        /// normal as unlike a single click which is processed on mouse up, a double click is processed immediately on the
-        /// mouse down.  Windows works like this too.  The mouse up done after releasing from double click is
-        /// suppressed but the mouse state will remain in a mouse down state but will do absolutely nothing until the mouse
-        /// button is released.  Note, all actions as described in HandleLeftMouseClick WILL be performed for the first mouse
-        /// click in the double click sequence, so your code may have to consider this if handling both single click and double
-        /// click events.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleLeftMouseDoubleClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle left mouse double click.  Unlike a left mouse click, no mouse up event is sent for this action - this is
+    /// normal as unlike a single click which is processed on mouse up, a double click is processed immediately on the
+    /// mouse down.  Windows works like this too.  The mouse up done after releasing from double click is
+    /// suppressed but the mouse state will remain in a mouse down state but will do absolutely nothing until the mouse
+    /// button is released.  Note, all actions as described in HandleLeftMouseClick WILL be performed for the first mouse
+    /// click in the double click sequence, so your code may have to consider this if handling both single click and double
+    /// click events.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleLeftMouseDoubleClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle left mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
-        /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
-        /// the same place within the threshold then a mouse up and mouse click event will be sent.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        void HandleLeftMouseDown(MouseState mouseState);
+    /// <summary>
+    /// Handle left mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
+    /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
+    /// the same place within the threshold then a mouse up and mouse click event will be sent.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    void HandleLeftMouseDown(MouseState mouseState);
 
-        /// <summary>
-        /// Handle left mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
-        /// called at the end of a double click.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleLeftMouseUp(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle left mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
+    /// called at the end of a double click.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleLeftMouseUp(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
-        /// every update while the mouse moves.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleLeftMouseDragging(MouseState mouseState, MouseState originalMouseState);
+    /// <summary>
+    /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
+    /// every update while the mouse moves.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleLeftMouseDragging(MouseState mouseState, MouseState originalMouseState);
 
-        /// <summary>
-        /// Handle left mouse drag completion.  A mouse up event is sent just prior to this event.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleLeftMouseDragDone(MouseState mouseState, MouseState originalMouseState);
+    /// <summary>
+    /// Handle left mouse drag completion.  A mouse up event is sent just prior to this event.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleLeftMouseDragDone(MouseState mouseState, MouseState originalMouseState);
 
-        /// <summary>
-        /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleRightMouseClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleRightMouseClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle right mouse double click.  See left mouse double click description for in depth info.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleRightMouseDoubleClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle right mouse double click.  See left mouse double click description for in depth info.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleRightMouseDoubleClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle right mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
-        /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
-        /// the same place within the threshold then a mouse up and mouse click event will be sent.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        void HandleRightMouseDown(MouseState mouseState);
+    /// <summary>
+    /// Handle right mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
+    /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
+    /// the same place within the threshold then a mouse up and mouse click event will be sent.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    void HandleRightMouseDown(MouseState mouseState);
 
-        /// <summary>
-        /// Handle right mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
-        /// called at the end of a double click.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleRightMouseUp(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle right mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
+    /// called at the end of a double click.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleRightMouseUp(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
-        /// every update while the mouse moves.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleRightMouseDragging(MouseState mouseState, MouseState originalMouseState);
+    /// <summary>
+    /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
+    /// every update while the mouse moves.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleRightMouseDragging(MouseState mouseState, MouseState originalMouseState);
 
-        /// <summary>
-        /// Handle right mouse drag completion.  A mouse up event is sent just prior to this event.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleRightMouseDragDone(MouseState mouseState, MouseState originalMouseState);
+    /// <summary>
+    /// Handle right mouse drag completion.  A mouse up event is sent just prior to this event.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleRightMouseDragDone(MouseState mouseState, MouseState originalMouseState);
 
-        /// <summary>
-        /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleMiddleMouseClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle left mouse click.  A mouse up event is sent just prior to this and is followed up by this event.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleMiddleMouseClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle middle mouse double click.  See left mouse double click description for in depth info.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleMiddleMouseDoubleClick(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle middle mouse double click.  See left mouse double click description for in depth info.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleMiddleMouseDoubleClick(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle middle mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
-        /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
-        /// the same place within the threshold then a mouse up and mouse click event will be sent.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        void HandleMiddleMouseDown(MouseState mouseState);
+    /// <summary>
+    /// Handle middle mouse down.  If the user holds down the mouse button and moves the mouse past the threshold for
+    /// dragging then HandleLeftMouseDragging events will be sent afterwards.  If the user eventually releases the mouse in
+    /// the same place within the threshold then a mouse up and mouse click event will be sent.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    void HandleMiddleMouseDown(MouseState mouseState);
 
-        /// <summary>
-        /// Handle middle mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
-        /// called at the end of a double click.
-        /// </summary>
-        /// <param name="mouseState">State of mouse when handler was called</param>
-        /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
-        void HandleMiddleMouseUp(MouseState mouseState, MouseState origin);
+    /// <summary>
+    /// Handle middle mouse up.  This event is only called at the end of a single click or dragging is done.  It is not
+    /// called at the end of a double click.
+    /// </summary>
+    /// <param name="mouseState">State of mouse when handler was called</param>
+    /// <param name="origin">State of mouse when button went down.  The position in here is generally the one you want to use for determining click location.</param>
+    void HandleMiddleMouseUp(MouseState mouseState, MouseState origin);
 
-        /// <summary>
-        /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
-        /// every update while the mouse moves.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleMiddleMouseDragging(MouseState mouseState, MouseState originalMouseState);
+    /// <summary>
+    /// Handle the situation where the mouse is being held down while the mouse is moving.  This event is continuously sent
+    /// every update while the mouse moves.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleMiddleMouseDragging(MouseState mouseState, MouseState originalMouseState);
 
-        /// <summary>
-        /// Handle middle mouse drag completion.  A mouse up event is sent just prior to this event.
-        /// </summary>
-        /// <param name="mouseState">state of mouse when handler was called</param>
-        /// <param name="originalMouseState">
-        /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
-        /// drag was initiated
-        /// </param>
-        void HandleMiddleMouseDragDone(MouseState mouseState, MouseState originalMouseState);
-    }
+    /// <summary>
+    /// Handle middle mouse drag completion.  A mouse up event is sent just prior to this event.
+    /// </summary>
+    /// <param name="mouseState">state of mouse when handler was called</param>
+    /// <param name="originalMouseState">
+    /// State of the mouse when drag was initiated.  This can be used to retrieve the position where the
+    /// drag was initiated
+    /// </param>
+    void HandleMiddleMouseDragDone(MouseState mouseState, MouseState originalMouseState);
 }

--- a/InputHandlers/IMouseInput.cs
+++ b/InputHandlers/IMouseInput.cs
@@ -1,50 +1,50 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Mouse
+namespace InputHandlers;
+
+public interface IMouseInput
 {
-    public interface IMouseInput
-    {
-        MouseState OldMouseState { get; }
-        MouseState CurrentMouseState { get; }
-        MouseState DragOriginPosition { get; }
-        IStopwatchProvider StopwatchProvider { get; }
-        bool IsLeftButtonEnabled { get; set; }
-        bool IsMiddleButtonEnabled { get; set; }
-        bool IsRightButtonEnabled { get; set; }
+    MouseState OldMouseState { get; }
+    MouseState CurrentMouseState { get; }
+    MouseState DragOriginPosition { get; }
+    IStopwatchProvider StopwatchProvider { get; }
+    bool IsLeftButtonEnabled { get; set; }
+    bool IsMiddleButtonEnabled { get; set; }
+    bool IsRightButtonEnabled { get; set; }
 
-        /// <summary>
-        /// DragVariance is a fudging factor for detecting the difference between mouse clicks and mouse drags.
-        /// This is because a fast user may do a mouse click while slightly moving the mouse between mouse down and mouse up.
-        /// If it wasnt for this fudging factor then it would go into drag mode which isnt what the user probably wanted.
-        /// </summary>
-        int DragVariance { get; set; }
+    /// <summary>
+    /// DragVariance is a fudging factor for detecting the difference between mouse clicks and mouse drags.
+    /// This is because a fast user may do a mouse click while slightly moving the mouse between mouse down and mouse up.
+    /// If it wasnt for this fudging factor then it would go into drag mode which isnt what the user probably wanted.
+    /// </summary>
+    int DragVariance { get; set; }
 
-        /// <summary>
-        /// If time between clicks in milliseconds is less than this value then it is considered a double click
-        /// </summary>
-        int DoubleClickDetectionTimeDelay { get; set; }
+    /// <summary>
+    /// If time between clicks in milliseconds is less than this value then it is considered a double click
+    /// </summary>
+    int DoubleClickDetectionTimeDelay { get; set; }
 
-        /// <summary>
-        /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
-        /// </summary>
-        int UpdateNumber { get; }
+    /// <summary>
+    /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
+    /// </summary>
+    int UpdateNumber { get; }
 
-        void Subscribe(IMouseHandler mouseHandler);
-        void Unsubscribe(IMouseHandler mouseHandler);
+    /// <summary>
+    /// Whether to wait for a neutral mouse state before applying pending subscriptions. Old subscriptions are still removed immediately. Defaults to False.
+    /// </summary>
+    bool WaitForNeutralStateBeforeApplyingNewSubscriptions { get; set; }
 
-        /// <summary>
-        /// Poll the mouse for updates.
-        /// </summary>
-        /// <param name="mouseState">a mouse state.  You should use the XNA input function, Mouse.GetState(), as this parameter.</param>
-        void Poll(MouseState mouseState);
+    void Subscribe(IMouseHandler mouseHandler);
+    void Unsubscribe(IMouseHandler mouseHandler);
 
-        /// <summary>
-        /// Reset to stationary state.  You may wish to call this when, for example, switching interface screens.
-        /// </summary>
-        void Reset();
-    }
+    /// <summary>
+    /// Poll the mouse for updates.
+    /// </summary>
+    /// <param name="mouseState">a mouse state.  You should use the XNA input function, Mouse.GetState(), as this parameter.</param>
+    void Poll(MouseState mouseState);
+
+    /// <summary>
+    /// Reset to stationary state.  You may wish to call this when, for example, switching interface screens.
+    /// </summary>
+    void Reset();
 }

--- a/InputHandlers/IMouseInput.cs
+++ b/InputHandlers/IMouseInput.cs
@@ -47,4 +47,13 @@ public interface IMouseInput
     /// Reset to stationary state.  You may wish to call this when, for example, switching interface screens.
     /// </summary>
     void Reset();
+
+    /// <summary>
+    /// Use this if you want to suppress double click detection (clears left, middle and right all at once).
+    /// May be useful for scenarios where you want to suppress clicks under some circumstances e.g. if the user
+    /// double clicks a button to close a window rather than single clicks and the click is subsequently
+    /// detected afterwards incorrectly as a different action. You could call this after the window closes
+    /// to suppress the double click. 
+    /// </summary>
+    void ResetDoubleClickDetection();
 }

--- a/InputHandlers/IStopwatchProvider.cs
+++ b/InputHandlers/IStopwatchProvider.cs
@@ -1,12 +1,11 @@
 using System;
 
-namespace InputHandlers
+namespace InputHandlers;
+
+public interface IStopwatchProvider
 {
-    public interface IStopwatchProvider
-    {
-        void Start();
-        void Stop();
-        void Reset();
-        TimeSpan Elapsed { get; }
-    }
+    void Start();
+    void Stop();
+    void Reset();
+    TimeSpan Elapsed { get; }
 }

--- a/InputHandlers/InputHandlers.csproj
+++ b/InputHandlers/InputHandlers.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <RootNamespace>InputHandlers</RootNamespace>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <PackageId>InputHandlers.MonoGame</PackageId>
     <Authors>David Fidge</Authors>
-    <Description>Input Handling library for MonoGame</Description>
+    <Description>Input Handling library for MonoGame. For more information, go to the Github page using the Project Website link.</Description>
     <Copyright>Copyright 2022</Copyright>
     <PackageProjectUrl>https://github.com/DavidFidge/InputHandlers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/DavidFidge/InputHandlers</RepositoryUrl>
-    <PackageReleaseNotes>Upgrade MonoGame to 3.8.1. Change target framework project setting to support .Net 6 only.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added subscription timestamps. Added a flag so that subscription adds can be delayed until an input rest state is achieved.</PackageReleaseNotes>
     <PackageTags>MonoGame;Input;Mouse;Keyboard</PackageTags>
   </PropertyGroup>
 

--- a/InputHandlers/KeyDelta.cs
+++ b/InputHandlers/KeyDelta.cs
@@ -5,195 +5,194 @@ using System.Linq;
 
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers.Keyboard;
+
+internal class KeyDelta
 {
-    internal class KeyDelta
+    private class OrderedHashSet<T> : KeyedCollection<T, T>
     {
-        private class OrderedHashSet<T> : KeyedCollection<T, T>
+        protected override T GetKeyForItem(T item)
         {
-            protected override T GetKeyForItem(T item)
-            {
-                return item;
-            }
+            return item;
         }
+    }
 
-        private readonly IList<Keys> _unmanagedKeys;
-        private OrderedHashSet<Keys> _keysStack;
-        private Keys[] _lastKeyList;
-        private Keys[] _newKeyList;
-        private bool _requiresUpdate;
+    private readonly IList<Keys> _unmanagedKeys;
+    private OrderedHashSet<Keys> _keysStack;
+    private Keys[] _lastKeyList;
+    private Keys[] _newKeyList;
+    private bool _requiresUpdate;
 
-        public Keys FocusKey { get; private set; }
-        public Keys LastFocusKey { get; private set; }
-        public Keys NewestKey => _keysStack.Any() ? _keysStack.Last() : Keys.None;
-        public bool TreatModifiersAsKeys { get; set; }
+    public Keys FocusKey { get; private set; }
+    public Keys LastFocusKey { get; private set; }
+    public Keys NewestKey => _keysStack.Any() ? _keysStack.Last() : Keys.None;
+    public bool TreatModifiersAsKeys { get; set; }
 
-        public KeyboardModifier LastModifiers { get; private set; }
+    public KeyboardModifier LastModifiers { get; private set; }
 
-        public Keys[] NewKeyList
+    public Keys[] NewKeyList
+    {
+        get { return _newKeyList; }
+    }
+
+    public IList<Keys> NewKeyDelta { get; private set; }
+
+    public KeyboardModifier NewModifiers { get; private set; }
+
+    public KeyDelta(IList<Keys> unmanagedKeys)
+    {
+        _lastKeyList = Array.Empty<Keys>();
+        _newKeyList = Array.Empty<Keys>();
+        NewKeyDelta = new List<Keys>();
+        _keysStack = new OrderedHashSet<Keys>();
+        FocusKey = Keys.None;
+        TreatModifiersAsKeys = false;
+        _unmanagedKeys = unmanagedKeys;
+    }
+
+    public void Stop()
+    {
+        _requiresUpdate = false;
+    }
+
+    public void Update(KeyboardState currentKeyboardState)
+    {
+        if (_requiresUpdate)
         {
-            get { return _newKeyList; }
-        }
+            _lastKeyList = _newKeyList;
+            _newKeyList = currentKeyboardState.GetPressedKeys();
 
-        public IList<Keys> NewKeyDelta { get; private set; }
-
-        public KeyboardModifier NewModifiers { get; private set; }
-
-        public KeyDelta(IList<Keys> unmanagedKeys)
-        {
-            _lastKeyList = Array.Empty<Keys>();
-            _newKeyList = Array.Empty<Keys>();
-            NewKeyDelta = new List<Keys>();
-            _keysStack = new OrderedHashSet<Keys>();
-            FocusKey = Keys.None;
-            TreatModifiersAsKeys = false;
-            _unmanagedKeys = unmanagedKeys;
-        }
-
-        public void Stop()
-        {
-            _requiresUpdate = false;
-        }
-
-        public void Update(KeyboardState currentKeyboardState)
-        {
-            if (_requiresUpdate)
-            {
-                _lastKeyList = _newKeyList;
-                _newKeyList = currentKeyboardState.GetPressedKeys();
-
-                StripUnmanagedKeys(ref _newKeyList);
-
-                if (!TreatModifiersAsKeys)
-                {
-                    LastModifiers = NewModifiers;
-                    NewModifiers = _newKeyList.GetModifiers();
-                    StripModifiers(ref _newKeyList);
-                }
-
-                NewKeyDelta = _newKeyList.Except(_lastKeyList).ToList();
-
-                foreach (var key in NewKeyDelta)
-                    _keysStack.Add(key);
-
-                var removedKeys = _lastKeyList.Except(_newKeyList).ToList();
-
-                foreach (var removedKey in removedKeys)
-                {
-                    _keysStack.Remove(removedKey);
-                }
-
-                if (NewKeyDelta.Any())
-                {
-                    FocusKey = NewestKey;
-                    LastFocusKey = FocusKey;
-                }
-                else
-                {
-                    FocusKey = NewestKey;
-                }
-            }
-        }
-
-        public void Start(KeyboardState currentKeyboardState)
-        {
-            _lastKeyList = Array.Empty<Keys>();
-            _newKeyList = Array.Empty<Keys>();
-            _keysStack.Clear();
-            NewKeyDelta.Clear();
-
-            _requiresUpdate = true;
-            _lastKeyList = currentKeyboardState.GetPressedKeys();
-
-            StripUnmanagedKeys(ref _lastKeyList);
+            StripUnmanagedKeys(ref _newKeyList);
 
             if (!TreatModifiersAsKeys)
             {
-                LastModifiers = _lastKeyList.GetModifiers();
-                StripModifiers(ref _lastKeyList);
+                LastModifiers = NewModifiers;
+                NewModifiers = _newKeyList.GetModifiers();
+                StripModifiers(ref _newKeyList);
             }
 
-            FocusKey = Keys.None;
-        }
+            NewKeyDelta = _newKeyList.Except(_lastKeyList).ToList();
 
-        public bool AreKeysLost
-        {
-            get
+            foreach (var key in NewKeyDelta)
+                _keysStack.Add(key);
+
+            var removedKeys = _lastKeyList.Except(_newKeyList).ToList();
+
+            foreach (var removedKey in removedKeys)
             {
-                return _newKeyList.Length < _lastKeyList.Length;
+                _keysStack.Remove(removedKey);
             }
-        }
 
-        public bool HasNoAddedKeys
-        {
-            get
+            if (NewKeyDelta.Any())
             {
-                return !NewKeyDelta.Any();
+                FocusKey = NewestKey;
+                LastFocusKey = FocusKey;
             }
-        }
-
-        public bool HasAddedKeys
-        {
-            get
+            else
             {
-                return NewKeyDelta.Any();
+                FocusKey = NewestKey;
             }
         }
+    }
 
-        public bool HasNoKeysPressed
+    public void Start(KeyboardState currentKeyboardState)
+    {
+        _lastKeyList = Array.Empty<Keys>();
+        _newKeyList = Array.Empty<Keys>();
+        _keysStack.Clear();
+        NewKeyDelta.Clear();
+
+        _requiresUpdate = true;
+        _lastKeyList = currentKeyboardState.GetPressedKeys();
+
+        StripUnmanagedKeys(ref _lastKeyList);
+
+        if (!TreatModifiersAsKeys)
         {
-            get
+            LastModifiers = _lastKeyList.GetModifiers();
+            StripModifiers(ref _lastKeyList);
+        }
+
+        FocusKey = Keys.None;
+    }
+
+    public bool AreKeysLost
+    {
+        get
+        {
+            return _newKeyList.Length < _lastKeyList.Length;
+        }
+    }
+
+    public bool HasNoAddedKeys
+    {
+        get
+        {
+            return !NewKeyDelta.Any();
+        }
+    }
+
+    public bool HasAddedKeys
+    {
+        get
+        {
+            return NewKeyDelta.Any();
+        }
+    }
+
+    public bool HasNoKeysPressed
+    {
+        get
+        {
+            return !HasKeysPressed;
+        }
+    }
+
+    public bool HasKeysPressed
+    {
+        get
+        {
+            return _newKeyList.Any();
+        }
+    }
+
+    private bool IsUnmanagedKey(Keys key)
+    {
+        return _unmanagedKeys.Contains(key);
+    }
+
+    private void StripUnmanagedKeys(ref Keys[] keyList)
+    {
+        if (!_unmanagedKeys.Any())
+            return;
+
+        var keyListUpdateIndex = 0;
+
+        StripKeys(key => !IsUnmanagedKey(key), ref keyList, keyListUpdateIndex);
+    }
+
+    private void StripModifiers(ref Keys[] keyList)
+    {
+        var keyListUpdateIndex = 0;
+
+        StripKeys(key => !key.IsModifierKey(), ref keyList, keyListUpdateIndex);
+    }
+
+    private void StripKeys(Func<Keys, bool> keepKeyFunc, ref Keys[] keyList, int keyListUpdateIndex)
+    {
+        int keyListIndex;
+        for (keyListIndex = 0; keyListIndex < keyList.Length; keyListIndex++)
+        {
+            if (keepKeyFunc(keyList[keyListIndex]))
             {
-                return !HasKeysPressed;
+                keyList[keyListUpdateIndex] = keyList[keyListIndex];
+                keyListUpdateIndex++;
             }
         }
 
-        public bool HasKeysPressed
+        if (keyListUpdateIndex < keyList.Length)
         {
-            get
-            {
-                return _newKeyList.Any();
-            }
-        }
-
-        private bool IsUnmanagedKey(Keys key)
-        {
-            return _unmanagedKeys.Contains(key);
-        }
-
-        private void StripUnmanagedKeys(ref Keys[] keyList)
-        {
-            if (!_unmanagedKeys.Any())
-                return;
-
-            var keyListUpdateIndex = 0;
-
-            StripKeys(key => !IsUnmanagedKey(key), ref keyList, keyListUpdateIndex);
-        }
-
-        private void StripModifiers(ref Keys[] keyList)
-        {
-            var keyListUpdateIndex = 0;
-
-            StripKeys(key => !key.IsModifierKey(), ref keyList, keyListUpdateIndex);
-        }
-
-        private void StripKeys(Func<Keys, bool> keepKeyFunc, ref Keys[] keyList, int keyListUpdateIndex)
-        {
-            int keyListIndex;
-            for (keyListIndex = 0; keyListIndex < keyList.Length; keyListIndex++)
-            {
-                if (keepKeyFunc(keyList[keyListIndex]))
-                {
-                    keyList[keyListUpdateIndex] = keyList[keyListIndex];
-                    keyListUpdateIndex++;
-                }
-            }
-
-            if (keyListUpdateIndex < keyList.Length)
-            {
-                keyList = keyList.Take(keyListUpdateIndex).ToArray();
-            }
+            keyList = keyList.Take(keyListUpdateIndex).ToArray();
         }
     }
 }

--- a/InputHandlers/KeyboardHandlerSubscription.cs
+++ b/InputHandlers/KeyboardHandlerSubscription.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace InputHandlers.Keyboard;
+
+public class KeyboardHandlerSubscription
+{
+    protected bool Equals(KeyboardHandlerSubscription other)
+    {
+        return Equals(_keyboardHandler, other._keyboardHandler);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((KeyboardHandlerSubscription)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return (_keyboardHandler != null ? _keyboardHandler.GetHashCode() : 0);
+    }
+
+    public IKeyboardHandler KeyboardHandler => _keyboardHandler;
+    private readonly IKeyboardHandler _keyboardHandler;
+        
+    public TimeSpan SubscribedTime => _subscribedTime;
+    private TimeSpan _subscribedTime;
+        
+    public KeyboardHandlerSubscription(IKeyboardHandler keyboardHandler, IStopwatchProvider stopwatchProvider)
+    {
+        _keyboardHandler = keyboardHandler;
+        _subscribedTime = stopwatchProvider.Elapsed;
+    }
+    
+    public void UpdateSubscribedTime(IStopwatchProvider stopwatchProvider)
+    {
+        _subscribedTime = stopwatchProvider.Elapsed;
+    }
+}

--- a/InputHandlers/KeyboardInput.cs
+++ b/InputHandlers/KeyboardInput.cs
@@ -7,497 +7,527 @@ using InputHandlers.StateMachine;
 
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers.Keyboard;
+
+public class KeyboardInput : IKeyboardInput
 {
-    public class KeyboardInput : IKeyboardInput
+    private readonly StateMachine<KeyboardInput> _keyboardStateMachine;
+    private readonly KeyboardKeyDownState _keyboardKeyDownState = new KeyboardKeyDownState();
+    private readonly KeyboardKeyLostState _keyboardKeyLostState = new KeyboardKeyLostState();
+    private readonly KeyboardKeyRepeatState _keyboardKeyRepeatState = new KeyboardKeyRepeatState();
+    private readonly KeyboardUnpressedState _keyboardUnpressedState = new KeyboardUnpressedState();
+
+    private int _repeatDelay = 1000;
+    private int _repeatFrequency = 50;
+
+    private readonly HashSet<IKeyboardHandler> _keyboardHandlerSubscriptions = new HashSet<IKeyboardHandler>();
+    private readonly HashSet<KeyboardHandlerSubscription> _pendingAddedSubscriptions = new HashSet<KeyboardHandlerSubscription>();
+    private readonly HashSet<KeyboardHandlerSubscription> _pendingRemovedSubscriptions = new HashSet<KeyboardHandlerSubscription>();
+
+    public KeyboardState OldKeyboardState { get; private set; }
+    public KeyboardState CurrentKeyboardState { get; private set; }
+
+    public IList<Keys> UnmanagedKeys { get; private set; } = new List<Keys>();
+
+    public IStopwatchProvider StopwatchProvider { get; private set; }
+
+    private readonly KeyDelta _keyDelta;
+
+    /// <summary>
+    /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
+    /// </summary>
+    public int UpdateNumber { get; private set; }
+
+    /// <summary>
+    /// Sets time delay in milliseconds to wait for a key being held down until it repeats
+    /// </summary>
+    public int RepeatDelay
     {
-        private readonly StateMachine<KeyboardInput> _keyboardStateMachine;
-        private readonly KeyboardKeyDownState _keyboardKeyDownState = new KeyboardKeyDownState();
-        private readonly KeyboardKeyLostState _keyboardKeyLostState = new KeyboardKeyLostState();
-        private readonly KeyboardKeyRepeatState _keyboardKeyRepeatState = new KeyboardKeyRepeatState();
-        private readonly KeyboardUnpressedState _keyboardUnpressedState = new KeyboardUnpressedState();
-
-        private int _repeatDelay = 1000;
-        private int _repeatFrequency = 50;
-
-        private readonly HashSet<IKeyboardHandler> _keyboardHandlerSubscriptions = new HashSet<IKeyboardHandler>();
-        private readonly HashSet<IKeyboardHandler> _pendingAddedSubscriptions = new HashSet<IKeyboardHandler>();
-        private readonly HashSet<IKeyboardHandler> _pendingRemovedSubscriptions = new HashSet<IKeyboardHandler>();
-
-        public KeyboardState OldKeyboardState { get; private set; }
-        public KeyboardState CurrentKeyboardState { get; private set; }
-
-        public IList<Keys> UnmanagedKeys { get; private set; } = new List<Keys>();
-
-        public IStopwatchProvider StopwatchProvider { get; private set; }
-
-        private readonly KeyDelta _keyDelta;
-
-        /// <summary>
-        /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
-        /// </summary>
-        public int UpdateNumber { get; private set; }
-
-        /// <summary>
-        /// Sets time delay in milliseconds to wait for a key being held down until it repeats
-        /// </summary>
-        public int RepeatDelay
+        get => _repeatDelay;
+        set
         {
-            get => _repeatDelay;
-            set
-            {
-                if (value > 0)
-                    _repeatDelay = value;
-            }
+            if (value > 0)
+                _repeatDelay = value;
         }
+    }
 
-        /// <summary>
-        /// Set time in milliseconds between key repeats once it has started to repeat
-        /// </summary>
-        public int RepeatFrequency
+    /// <summary>
+    /// Set time in milliseconds between key repeats once it has started to repeat
+    /// </summary>
+    public int RepeatFrequency
+    {
+        get { return _repeatFrequency; }
+        set
         {
-            get { return _repeatFrequency; }
-            set
-            {
-                if (value > 0)
-                    _repeatFrequency = value;
-            }
+            if (value > 0)
+                _repeatFrequency = value;
         }
+    }
 
-        /// <summary>
-        /// Whether to treat modifier keys (ctrl/alt/shift) as actual keys
-        /// </summary>
-        public bool TreatModifiersAsKeys
-        {
-            get { return _keyDelta.TreatModifiersAsKeys; }
-            set { _keyDelta.TreatModifiersAsKeys = value; }
-        }
+    /// <summary>
+    /// Whether to treat modifier keys (ctrl/alt/shift) as actual keys
+    /// </summary>
+    public bool TreatModifiersAsKeys
+    {
+        get { return _keyDelta.TreatModifiersAsKeys; }
+        set { _keyDelta.TreatModifiersAsKeys = value; }
+    }
 
-        public bool IsRepeatEnabled { get; set; } = true;
+    /// <summary>
+    /// Whether to wait for a neutral keyboard state before applying new pending subscriptions. Old subscriptions are still removed immediately. Defaults to False.
+    /// </summary>
+    public bool WaitForNeutralStateBeforeApplyingNewSubscriptions { get; set; }
 
-        public KeyboardInput() : this(new StopwatchProvider())
-        {
-        }
+    public bool IsRepeatEnabled { get; set; } = true;
 
-        public KeyboardInput(IStopwatchProvider stopwatchProvider)
-        {
-            _keyDelta = new KeyDelta(UnmanagedKeys);
+    public KeyboardInput() : this(new StopwatchProvider())
+    {
+    }
+
+    public KeyboardInput(IStopwatchProvider stopwatchProvider)
+    {
+        _keyDelta = new KeyDelta(UnmanagedKeys);
             
-            StopwatchProvider = stopwatchProvider;
-            StopwatchProvider.Start();
+        StopwatchProvider = stopwatchProvider;
+        StopwatchProvider.Start();
 
-            _keyboardStateMachine = new StateMachine<KeyboardInput>(this);
-            _keyboardStateMachine.SetCurrentState(_keyboardUnpressedState);
-            _keyboardStateMachine.SetPreviousState(_keyboardUnpressedState);
-        }
+        _keyboardStateMachine = new StateMachine<KeyboardInput>(this);
+        _keyboardStateMachine.SetCurrentState(_keyboardUnpressedState);
+        _keyboardStateMachine.SetPreviousState(_keyboardUnpressedState);
+    }
 
-        public void Subscribe(IKeyboardHandler keyboardHandler)
+    public void Subscribe(IKeyboardHandler keyboardHandler)
+    {
+        if (keyboardHandler != null)
         {
-            if (keyboardHandler != null)
-                _pendingAddedSubscriptions.Add(keyboardHandler);
+            var existingSubscription = _pendingAddedSubscriptions.SingleOrDefault(s => s.KeyboardHandler.Equals(keyboardHandler));
+            
+            if (existingSubscription != null)
+                existingSubscription.UpdateSubscribedTime(StopwatchProvider);
+            else
+                _pendingAddedSubscriptions.Add(new KeyboardHandlerSubscription(keyboardHandler, StopwatchProvider));
         }
+    }
 
-        public void Unsubscribe(IKeyboardHandler keyboardHandler)
+    public void Unsubscribe(IKeyboardHandler keyboardHandler)
+    {
+        if (keyboardHandler != null)
         {
-            if (keyboardHandler != null)
-                _pendingRemovedSubscriptions.Add(keyboardHandler);
+            var existingSubscription = _pendingRemovedSubscriptions.SingleOrDefault(s => s.KeyboardHandler.Equals(keyboardHandler));
+            
+            if (existingSubscription != null)
+                existingSubscription.UpdateSubscribedTime(StopwatchProvider);
+            else
+                _pendingRemovedSubscriptions.Add(new KeyboardHandlerSubscription(keyboardHandler, StopwatchProvider));
         }
+    }
 
-        private void CallHandleKeyboardKeyDown(Keys[] keysDown, Keys focus, KeyboardModifier keyboardModifier)
+    private void CallHandleKeyboardKeyDown(Keys[] keysDown, Keys focus, KeyboardModifier keyboardModifier)
+    {
+        foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
         {
-            foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
-            {
-                keyboardHandler.HandleKeyboardKeyDown(keysDown, focus, keyboardModifier);
-            }
+            keyboardHandler.HandleKeyboardKeyDown(keysDown, focus, keyboardModifier);
         }
+    }
 
-        private void CallHandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier)
+    private void CallHandleKeyboardKeyLost(Keys[] keysDown, KeyboardModifier keyboardModifier)
+    {
+        foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
         {
-            foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
-            {
-                keyboardHandler.HandleKeyboardKeyLost(keysDown, keyboardModifier);
-            }
+            keyboardHandler.HandleKeyboardKeyLost(keysDown, keyboardModifier);
         }
+    }
 
-        private void CallHandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier)
+    private void CallHandleKeyboardKeyRepeat(Keys repeatingKey, KeyboardModifier keyboardModifier)
+    {
+        foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
         {
-            foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
-            {
-                keyboardHandler.HandleKeyboardKeyRepeat(repeatingKey, keyboardModifier);
-            }
+            keyboardHandler.HandleKeyboardKeyRepeat(repeatingKey, keyboardModifier);
         }
+    }
 
-        private void CallHandleKeyboardKeysReleased()
+    private void CallHandleKeyboardKeysReleased()
+    {
+        foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
         {
-            foreach (var keyboardHandler in _keyboardHandlerSubscriptions)
-            {
-                keyboardHandler.HandleKeyboardKeysReleased();
-            }
+            keyboardHandler.HandleKeyboardKeysReleased();
         }
+    }
 
-        /// <summary>
-        /// Poll the keyboard for updates.
-        /// </summary>
-        /// <param name="keyboardState">a keyboard state.  You should use the XNA input function, Keyboard.GetState(), as this parameter.</param>
-        public void Poll(KeyboardState keyboardState)
-        {
-            UpdateNumber++;
+    /// <summary>
+    /// Poll the keyboard for updates.
+    /// </summary>
+    /// <param name="keyboardState">a keyboard state.  You should use the XNA input function, Keyboard.GetState(), as this parameter.</param>
+    public void Poll(KeyboardState keyboardState)
+    {
+        UpdateNumber++;
 
-            if (UpdateNumber == int.MaxValue)
-                UpdateNumber = 0;
-
-            OldKeyboardState = CurrentKeyboardState;
-            CurrentKeyboardState = keyboardState;
-
-            _keyDelta.Update(CurrentKeyboardState);
-
-            UpdateSubscriptions();
-
-            _keyboardStateMachine.Update();
-        }
-
-        private void UpdateSubscriptions()
-        {
-            foreach (var pendingAddedSubscription in _pendingAddedSubscriptions)
-                _keyboardHandlerSubscriptions.Add(pendingAddedSubscription);
-
-            foreach (var pendingRemovedSubscriptions in _pendingRemovedSubscriptions)
-                _keyboardHandlerSubscriptions.Remove(pendingRemovedSubscriptions);
-
-            _pendingAddedSubscriptions.Clear();
-            _pendingRemovedSubscriptions.Clear();
-        }
-
-        /// <summary>
-        /// Reset to unpressed state.  You may wish to call this when, for example, switching interface screens.
-        /// </summary>
-        public void Reset()
-        {
-            StopwatchProvider.Stop();
-            StopwatchProvider.Reset();
-            StopwatchProvider.Start();
-
+        if (UpdateNumber == int.MaxValue)
             UpdateNumber = 0;
-            _keyDelta.Stop();
 
-            _keyboardStateMachine.CurrentState.Reset(this);
-            _keyboardStateMachine.SetCurrentState(_keyboardUnpressedState);
-            _keyboardStateMachine.SetPreviousState(_keyboardUnpressedState);
+        OldKeyboardState = CurrentKeyboardState;
+        CurrentKeyboardState = keyboardState;
+
+        _keyDelta.Update(CurrentKeyboardState);
+
+        UpdateSubscriptions();
+
+        _keyboardStateMachine.Update();
+    }
+
+    private void UpdateSubscriptions()
+    {
+        foreach (var pendingRemovedSubscription in _pendingRemovedSubscriptions)
+        {
+            _keyboardHandlerSubscriptions.Remove(pendingRemovedSubscription.KeyboardHandler);
+
+            var addedSubscription =
+                _pendingAddedSubscriptions.SingleOrDefault(s => s.Equals(pendingRemovedSubscription));
+
+            if (addedSubscription != null && pendingRemovedSubscription.SubscribedTime >= addedSubscription.SubscribedTime)
+                _pendingAddedSubscriptions.Remove(addedSubscription);
+        }
+            
+        _pendingRemovedSubscriptions.Clear();
+
+        if (WaitForNeutralStateBeforeApplyingNewSubscriptions && _keyboardStateMachine.CurrentState is not KeyboardUnpressedState)
+            return;
+            
+        foreach (var pendingAddedSubscription in _pendingAddedSubscriptions)
+            _keyboardHandlerSubscriptions.Add(pendingAddedSubscription.KeyboardHandler);
+
+        _pendingAddedSubscriptions.Clear();
+    }
+
+    /// <summary>
+    /// Reset to unpressed state.  You may wish to call this when, for example, switching interface screens.
+    /// </summary>
+    public void Reset()
+    {
+        StopwatchProvider.Stop();
+        StopwatchProvider.Reset();
+        StopwatchProvider.Start();
+
+        UpdateNumber = 0;
+        _keyDelta.Stop();
+
+        _keyboardStateMachine.CurrentState.Reset(this);
+        _keyboardStateMachine.SetCurrentState(_keyboardUnpressedState);
+        _keyboardStateMachine.SetPreviousState(_keyboardUnpressedState);
+    }
+
+    public string GetCurrentStateTypeName()
+    {
+        return _keyboardStateMachine.GetCurrentStateTypeName();
+    }
+
+    private sealed class KeyboardUnpressedState : State<KeyboardInput>
+    {
+        public override void Enter(KeyboardInput keyboardInput)
+        {
+            keyboardInput.CallHandleKeyboardKeysReleased();
+            keyboardInput._keyDelta.Stop();
         }
 
-        public string GetCurrentStateTypeName()
+        public override void Execute(KeyboardInput keyboardInput)
         {
-            return _keyboardStateMachine.GetCurrentStateTypeName();
-        }
+            var pressedKeys = keyboardInput.CurrentKeyboardState.GetPressedKeys();
 
-        private sealed class KeyboardUnpressedState : State<KeyboardInput>
-        {
-            public override void Enter(KeyboardInput keyboardInput)
+            foreach (var key in pressedKeys)
             {
-                keyboardInput.CallHandleKeyboardKeysReleased();
-                keyboardInput._keyDelta.Stop();
+                if (!keyboardInput.UnmanagedKeys.Contains(key))
+                {
+                    keyboardInput._keyDelta.Start(keyboardInput.CurrentKeyboardState);
+                    keyboardInput._keyDelta.Update(keyboardInput.CurrentKeyboardState);
+
+                    if (keyboardInput._keyDelta.HasKeysPressed)
+                    {
+                        keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
+                    }
+                    else
+                    {
+                        keyboardInput._keyDelta.Stop();
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        public override void Exit(KeyboardInput keyboardInput)
+        {
+        }
+
+        public override void Reset(KeyboardInput keyboardInput)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Key down state.  A key down event is sent for EVERY new key found.  If one or more modifier keys only then only one
+    /// kbkeydown is sent.
+    /// </summary>
+    private sealed class KeyboardKeyDownState : State<KeyboardInput>
+    {
+        private TimeSpan _elapsedTimeSinceKeysChanged;
+
+        public override void Enter(KeyboardInput keyboardInput)
+        {
+            var keyDelta = keyboardInput._keyDelta;
+
+            _elapsedTimeSinceKeysChanged = _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
+
+            foreach (var newkey in keyDelta.NewKeyDelta)
+            {
+                keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, newkey, keyDelta.NewModifiers);
+            }
+        }
+
+        public override void Execute(KeyboardInput keyboardInput)
+        {
+            var keyDelta = keyboardInput._keyDelta;
+
+            if (keyDelta.HasNoKeysPressed)
+            {
+                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
+                return;
             }
 
-            public override void Execute(KeyboardInput keyboardInput)
+            if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
             {
-                var pressedKeys = keyboardInput.CurrentKeyboardState.GetPressedKeys();
-
-                foreach (var key in pressedKeys)
+                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
+            }
+            else
+            {
+                if (keyDelta.HasNoAddedKeys)
                 {
-                    if (!keyboardInput.UnmanagedKeys.Contains(key))
+                    if (keyDelta.NewModifiers != keyDelta.LastModifiers)
                     {
-                        keyboardInput._keyDelta.Start(keyboardInput.CurrentKeyboardState);
-                        keyboardInput._keyDelta.Update(keyboardInput.CurrentKeyboardState);
+                        _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
 
-                        if (keyboardInput._keyDelta.HasKeysPressed)
+                        var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
+
+                        if (modifierDiff == KeyboardModifier.None
+                            || (modifierDiff & keyDelta.NewModifiers) == (modifierDiff & keyDelta.LastModifiers))
                         {
+                            // had one key the same but other two were different, send keyboard down
+                            keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, Keys.None, keyDelta.NewModifiers);
+                        }
+                        else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
+                        {
+                            // new mod bits only had 1, which means it lost one, change to lost state
+                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
+                        }
+                        else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
+                        {
+                            // old mod bits is less, send down event
+                            keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, Keys.None, keyDelta.NewModifiers);
+                        }
+                        else
+                            throw new Exception("code error, unhandled mod key state");
+                    }
+                    else if (keyboardInput.IsRepeatEnabled
+                             && keyDelta.FocusKey != Keys.None
+                             && keyboardInput.StopwatchProvider.Elapsed.TotalMilliseconds - _elapsedTimeSinceKeysChanged.TotalMilliseconds >=
+                             keyboardInput._repeatDelay
+                            )
+                    {
+                        keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyRepeatState);
+                    }
+                }
+                else
+                {
+                    foreach (var newkey in keyDelta.NewKeyDelta)
+                    {
+                        keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, newkey, keyDelta.NewModifiers);
+
+                        _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
+                    }
+                }
+            }
+        }
+
+        public override void Exit(KeyboardInput keyboardInput)
+        {
+        }
+
+        public override void Reset(KeyboardInput keyboardInput)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Key lost state happens when one or more keys are released but keys are still being held down.  Only one
+    /// kbkeylost event is sent regardless of how many keys were lost.
+    /// note - sometimes more than 2 keys wont register.  See this for explanation of keyboard hardware limitations:
+    /// http://blogs.msdn.com/shawnhar/archive/2007/03/28/keyboards-suck.aspx
+    /// 2nd note - GetPressedKeys has a few other issues too - for example, holding down shift and pressing numpad9 or
+    /// numpad3 will register a pageup/pagedown key in XNA, then on releasing the shift key and then releasing the numpad
+    /// key will cause unexpected behaviour.
+    /// </summary>
+    private sealed class KeyboardKeyLostState : State<KeyboardInput>
+    {
+        private TimeSpan _elapsedTimeSinceKeyLost;
+
+        public override void Enter(KeyboardInput keyboardInput)
+        {
+            var keyDelta = keyboardInput._keyDelta;
+
+            _elapsedTimeSinceKeyLost = _elapsedTimeSinceKeyLost = keyboardInput.StopwatchProvider.Elapsed;
+
+            keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
+        }
+
+        public override void Execute(KeyboardInput keyboardInput)
+        {
+            var keyDelta = keyboardInput._keyDelta;
+
+            if (keyDelta.HasNoKeysPressed)
+            {
+                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
+                return;
+            }
+
+            if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
+            {
+                keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
+            }
+            else
+            {
+                if (keyDelta.HasNoAddedKeys)
+                {
+                    if (keyDelta.NewModifiers != keyDelta.LastModifiers)
+                    {
+                        _elapsedTimeSinceKeyLost = keyboardInput.StopwatchProvider.Elapsed;
+
+                        var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
+
+                        if ((modifierDiff == KeyboardModifier.None)
+                            || ((modifierDiff & keyDelta.NewModifiers) == (modifierDiff & keyDelta.LastModifiers)))
+                        {
+                            // had one key the same but other two were different, send keyboard down
+                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
+                        }
+                        else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
+                        {
+                            // new mod bits only had 1, which means it lost one,
+                            // send key lost 
+                            keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
+                        }
+                        else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
+                        {
+                            // old mod bits is less, send down event
                             keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
                         }
                         else
-                        {
-                            keyboardInput._keyDelta.Stop();
-                        }
-
-                        break;
+                            throw new Exception("code error, unhandled mod key state");
+                    }
+                    else if (keyboardInput.IsRepeatEnabled
+                             && keyDelta.LastFocusKey != Keys.None
+                             && keyDelta.LastFocusKey == keyDelta.NewestKey
+                             && keyboardInput.StopwatchProvider.Elapsed.TotalMilliseconds - _elapsedTimeSinceKeyLost.TotalMilliseconds >=
+                             keyboardInput._repeatDelay
+                            )
+                    {
+                        keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyRepeatState);
                     }
                 }
-            }
-
-            public override void Exit(KeyboardInput keyboardInput)
-            {
-            }
-
-            public override void Reset(KeyboardInput keyboardInput)
-            {
+                else if (keyDelta.HasAddedKeys)
+                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
             }
         }
 
-        /// <summary>
-        /// Key down state.  A key down event is sent for EVERY new key found.  If one or more modifier keys only then only one
-        /// kbkeydown is sent.
-        /// </summary>
-        private sealed class KeyboardKeyDownState : State<KeyboardInput>
+        public override void Exit(KeyboardInput keyboardInput)
         {
-            private TimeSpan _elapsedTimeSinceKeysChanged;
-
-            public override void Enter(KeyboardInput keyboardInput)
-            {
-                var keyDelta = keyboardInput._keyDelta;
-
-                _elapsedTimeSinceKeysChanged = _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
-
-                foreach (var newkey in keyDelta.NewKeyDelta)
-                {
-                    keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, newkey, keyDelta.NewModifiers);
-                }
-            }
-
-            public override void Execute(KeyboardInput keyboardInput)
-            {
-                var keyDelta = keyboardInput._keyDelta;
-
-                if (keyDelta.HasNoKeysPressed)
-                {
-                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
-                    return;
-                }
-
-                if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
-                {
-                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
-                }
-                else
-                {
-                    if (keyDelta.HasNoAddedKeys)
-                    {
-                        if (keyDelta.NewModifiers != keyDelta.LastModifiers)
-                        {
-                            _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
-
-                            var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
-
-                            if (modifierDiff == KeyboardModifier.None
-                                || (modifierDiff & keyDelta.NewModifiers) == (modifierDiff & keyDelta.LastModifiers))
-                            {
-                                // had one key the same but other two were different, send keyboard down
-                                keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, Keys.None, keyDelta.NewModifiers);
-                            }
-                            else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
-                            {
-                                // new mod bits only had 1, which means it lost one, change to lost state
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
-                            }
-                            else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
-                            {
-                                // old mod bits is less, send down event
-                                keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, Keys.None, keyDelta.NewModifiers);
-                            }
-                            else
-                                throw new Exception("code error, unhandled mod key state");
-                        }
-                        else if (keyboardInput.IsRepeatEnabled
-                                 && keyDelta.FocusKey != Keys.None
-                                 && keyboardInput.StopwatchProvider.Elapsed.TotalMilliseconds - _elapsedTimeSinceKeysChanged.TotalMilliseconds >=
-                                     keyboardInput._repeatDelay
-                                 )
-                        {
-                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyRepeatState);
-                        }
-                    }
-                    else
-                    {
-                        foreach (var newkey in keyDelta.NewKeyDelta)
-                        {
-                            keyboardInput.CallHandleKeyboardKeyDown(keyDelta.NewKeyList, newkey, keyDelta.NewModifiers);
-
-                            _elapsedTimeSinceKeysChanged = keyboardInput.StopwatchProvider.Elapsed;
-                        }
-                    }
-                }
-            }
-
-            public override void Exit(KeyboardInput keyboardInput)
-            {
-            }
-
-            public override void Reset(KeyboardInput keyboardInput)
-            {
-            }
         }
 
-        /// <summary>
-        /// Key lost state happens when one or more keys are released but keys are still being held down.  Only one
-        /// kbkeylost event is sent regardless of how many keys were lost.
-        /// note - sometimes more than 2 keys wont register.  See this for explanation of keyboard hardware limitations:
-        /// http://blogs.msdn.com/shawnhar/archive/2007/03/28/keyboards-suck.aspx
-        /// 2nd note - GetPressedKeys has a few other issues too - for example, holding down shift and pressing numpad9 or
-        /// numpad3 will register a pageup/pagedown key in XNA, then on releasing the shift key and then releasing the numpad
-        /// key will cause unexpected behaviour.
-        /// </summary>
-        private sealed class KeyboardKeyLostState : State<KeyboardInput>
+        public override void Reset(KeyboardInput keyboardInput)
         {
-            private TimeSpan _elapsedTimeSinceKeyLost;
+        }
+    }
 
-            public override void Enter(KeyboardInput keyboardInput)
-            {
-                var keyDelta = keyboardInput._keyDelta;
+    /// <summary>
+    /// Key repeat state is entered when a key is held down for long enough and nothing else occurs.  A key repeat
+    /// event happens every single time a poll occurs if the repeat delay time has been exceeded.
+    /// </summary>
+    private sealed class KeyboardKeyRepeatState : State<KeyboardInput>
+    {
+        private TimeSpan _lastTime;
+        private double _repeatRunning;
 
-                _elapsedTimeSinceKeyLost = _elapsedTimeSinceKeyLost = keyboardInput.StopwatchProvider.Elapsed;
-
-                keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
-            }
-
-            public override void Execute(KeyboardInput keyboardInput)
-            {
-                var keyDelta = keyboardInput._keyDelta;
-
-                if (keyDelta.HasNoKeysPressed)
-                {
-                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
-                    return;
-                }
-
-                if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
-                {
-                    keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
-                }
-                else
-                {
-                    if (keyDelta.HasNoAddedKeys)
-                    {
-                        if (keyDelta.NewModifiers != keyDelta.LastModifiers)
-                        {
-                            _elapsedTimeSinceKeyLost = keyboardInput.StopwatchProvider.Elapsed;
-
-                            var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
-
-                            if ((modifierDiff == KeyboardModifier.None)
-                                || ((modifierDiff & keyDelta.NewModifiers) == (modifierDiff & keyDelta.LastModifiers)))
-                            {
-                                // had one key the same but other two were different, send keyboard down
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
-                            }
-                            else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
-                            {
-                                // new mod bits only had 1, which means it lost one,
-                                // send key lost 
-                                keyboardInput.CallHandleKeyboardKeyLost(keyDelta.NewKeyList, keyDelta.NewModifiers);
-                            }
-                            else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
-                            {
-                                // old mod bits is less, send down event
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
-                            }
-                            else
-                                throw new Exception("code error, unhandled mod key state");
-                        }
-                        else if (keyboardInput.IsRepeatEnabled
-                                 && keyDelta.LastFocusKey != Keys.None
-                                 && keyDelta.LastFocusKey == keyDelta.NewestKey
-                                 && keyboardInput.StopwatchProvider.Elapsed.TotalMilliseconds - _elapsedTimeSinceKeyLost.TotalMilliseconds >=
-                                 keyboardInput._repeatDelay
-                                )
-                        {
-                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyRepeatState);
-                        }
-                    }
-                    else if (keyDelta.HasAddedKeys)
-                        keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
-                }
-            }
-
-            public override void Exit(KeyboardInput keyboardInput)
-            {
-            }
-
-            public override void Reset(KeyboardInput keyboardInput)
-            {
-            }
+        public override void Enter(KeyboardInput keyboardInput)
+        {
+            _repeatRunning = 0;
+            Execute(keyboardInput);
         }
 
-        /// <summary>
-        /// Key repeat state is entered when a key is held down for long enough and nothing else occurs.  A key repeat
-        /// event happens every single time a poll occurs if the repeat delay time has been exceeded.
-        /// </summary>
-        private sealed class KeyboardKeyRepeatState : State<KeyboardInput>
+        public override void Execute(KeyboardInput keyboardInput)
         {
-            private TimeSpan _lastTime;
-            private double _repeatRunning;
+            var keyDelta = keyboardInput._keyDelta;
 
-            public override void Enter(KeyboardInput keyboardInput)
+            if (keyDelta.NewKeyList.Length == 0)
             {
-                _repeatRunning = 0;
-                Execute(keyboardInput);
+                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
+                return;
             }
 
-            public override void Execute(KeyboardInput keyboardInput)
+            if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
             {
-                var keyDelta = keyboardInput._keyDelta;
-
-                if (keyDelta.NewKeyList.Length == 0)
+                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
+            }
+            else
+            {
+                if (keyDelta.HasNoAddedKeys)
                 {
-                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardUnpressedState);
-                    return;
-                }
-
-                if (keyDelta.AreKeysLost && keyDelta.HasNoAddedKeys)
-                {
-                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
-                }
-                else
-                {
-                    if (keyDelta.HasNoAddedKeys)
+                    if (keyDelta.NewModifiers != keyDelta.LastModifiers)
                     {
-                        if (keyDelta.NewModifiers != keyDelta.LastModifiers)
-                        {
-                            var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
+                        var modifierDiff = keyDelta.NewModifiers & keyDelta.LastModifiers;
 
-                            if (modifierDiff == KeyboardModifier.None || (modifierDiff & keyDelta.NewModifiers) ==
-                                    (modifierDiff & keyDelta.LastModifiers))
-                            {
-                                // had one key the same but other two were different, send keyboard down
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
-                            }
-                            else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
-                            {
-                                // new mod bits only had 1, which means it lost one, change to lost state
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
-                            }
-                            else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
-                            {
-                                // old mod bits is less, send down event
-                                keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
-                            }
-                            else
-                                throw new Exception("code error, unhandled mod key state");
+                        if (modifierDiff == KeyboardModifier.None || (modifierDiff & keyDelta.NewModifiers) ==
+                            (modifierDiff & keyDelta.LastModifiers))
+                        {
+                            // had one key the same but other two were different, send keyboard down
+                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
+                        }
+                        else if ((modifierDiff & keyDelta.NewModifiers) == modifierDiff)
+                        {
+                            // new mod bits only had 1, which means it lost one, change to lost state
+                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyLostState);
+                        }
+                        else if ((modifierDiff & keyDelta.LastModifiers) == modifierDiff)
+                        {
+                            // old mod bits is less, send down event
+                            keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
                         }
                         else
-                        {
-                            _repeatRunning -= (keyboardInput.StopwatchProvider.Elapsed - _lastTime).TotalMilliseconds;
-                            _lastTime = keyboardInput.StopwatchProvider.Elapsed;
-
-                            if (_repeatRunning <= 0)
-                            {
-                                keyboardInput.CallHandleKeyboardKeyRepeat(
-                                    keyDelta.FocusKey,
-                                    keyDelta.LastModifiers);
-                                _repeatRunning = keyboardInput._repeatFrequency;
-                            }
-                        }
+                            throw new Exception("code error, unhandled mod key state");
                     }
                     else
-                        keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
+                    {
+                        _repeatRunning -= (keyboardInput.StopwatchProvider.Elapsed - _lastTime).TotalMilliseconds;
+                        _lastTime = keyboardInput.StopwatchProvider.Elapsed;
+
+                        if (_repeatRunning <= 0)
+                        {
+                            keyboardInput.CallHandleKeyboardKeyRepeat(
+                                keyDelta.FocusKey,
+                                keyDelta.LastModifiers);
+                            _repeatRunning = keyboardInput._repeatFrequency;
+                        }
+                    }
                 }
-
+                else
+                    keyboardInput._keyboardStateMachine.ChangeState(keyboardInput._keyboardKeyDownState);
             }
 
-            public override void Exit(KeyboardInput keyboardInput)
-            {
-            }
+        }
 
-            public override void Reset(KeyboardInput keyboardInput)
-            {
-            }
+        public override void Exit(KeyboardInput keyboardInput)
+        {
+        }
+
+        public override void Reset(KeyboardInput keyboardInput)
+        {
         }
     }
 }

--- a/InputHandlers/KeyboardModifier.cs
+++ b/InputHandlers/KeyboardModifier.cs
@@ -3,20 +3,19 @@ using System;
 using System.Linq;
 
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers.Keyboard;
+
+/// <summary>
+/// This is a bit field for "modifier" keys, i.e. control, shift and alt keys.
+/// Bit 1 = either control key down
+/// Bit 2 = either shift key down
+/// Bit 3 = either alt key down
+/// </summary>
+[Flags]
+public enum KeyboardModifier
 {
-    /// <summary>
-    /// This is a bit field for "modifier" keys, i.e. control, shift and alt keys.
-    /// Bit 1 = either control key down
-    /// Bit 2 = either shift key down
-    /// Bit 3 = either alt key down
-    /// </summary>
-    [Flags]
-    public enum KeyboardModifier
-    {
-        None = 0,
-        Ctrl = 1,
-        Shift = 2,
-        Alt = 4
-    }
+    None = 0,
+    Ctrl = 1,
+    Shift = 2,
+    Alt = 4
 }

--- a/InputHandlers/KeysExtensions.cs
+++ b/InputHandlers/KeysExtensions.cs
@@ -4,282 +4,281 @@ using System.Linq;
 
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Keyboard
+namespace InputHandlers.Keyboard;
+
+public static class KeysExtensions
 {
-    public static class KeysExtensions
+    public static bool IsKeyAlpha(this Keys key)
     {
-        public static bool IsKeyAlpha(this Keys key)
-        {
-            return key >= Keys.A && key <= Keys.Z;
-        }
+        return key >= Keys.A && key <= Keys.Z;
+    }
 
-        public static bool IsKeyNumber(this Keys key)
-        {
-            return key >= Keys.D0 && key <= Keys.D9;
-        }
+    public static bool IsKeyNumber(this Keys key)
+    {
+        return key >= Keys.D0 && key <= Keys.D9;
+    }
 
-        public static bool IsKeyNumberpad(this Keys key)
-        {
-            return key >= Keys.NumPad0 && key <= Keys.NumPad9;
-        }
+    public static bool IsKeyNumberpad(this Keys key)
+    {
+        return key >= Keys.NumPad0 && key <= Keys.NumPad9;
+    }
 
-        public static bool IsKeyNumeric(this Keys key, bool treatNumpadAsNumeric = true)
-        {
-            if (IsKeyNumber(key))
-                return true;
+    public static bool IsKeyNumeric(this Keys key, bool treatNumpadAsNumeric = true)
+    {
+        if (IsKeyNumber(key))
+            return true;
 
-            return treatNumpadAsNumeric && IsKeyNumberpad(key);
-        }
+        return treatNumpadAsNumeric && IsKeyNumberpad(key);
+    }
 
-        public static bool IsKeyAlphanumeric(this Keys key)
-        {
-            return IsKeyAlpha(key) || IsKeyNumeric(key);
-        }
+    public static bool IsKeyAlphanumeric(this Keys key)
+    {
+        return IsKeyAlpha(key) || IsKeyNumeric(key);
+    }
 
-        public static bool IsFunctionKey(this Keys key)
-        {
-            return key >= Keys.F1 && key <= Keys.F12;
-        }
+    public static bool IsFunctionKey(this Keys key)
+    {
+        return key >= Keys.F1 && key <= Keys.F12;
+    }
 
-        public static bool IsKeySpace(this Keys key)
-        {
-            return key == Keys.Space;
-        }
+    public static bool IsKeySpace(this Keys key)
+    {
+        return key == Keys.Space;
+    }
 
-        public static bool IsShift(this Keys key)
-        {
-            return key == Keys.LeftShift || key == Keys.RightShift;
-        }
+    public static bool IsShift(this Keys key)
+    {
+        return key == Keys.LeftShift || key == Keys.RightShift;
+    }
 
-        public static bool IsCtrl(this Keys key)
-        {
-            return key == Keys.LeftControl || key == Keys.RightControl;
-        }
+    public static bool IsCtrl(this Keys key)
+    {
+        return key == Keys.LeftControl || key == Keys.RightControl;
+    }
 
-        public static bool IsAlt(this Keys key)
-        {
-            return key == Keys.LeftAlt || key == Keys.RightAlt;
-        }
+    public static bool IsAlt(this Keys key)
+    {
+        return key == Keys.LeftAlt || key == Keys.RightAlt;
+    }
 
-        public static bool IsShiftDown(this KeyboardModifier keyboardModifier)
-        {
-            if ((KeyboardModifier.Shift & keyboardModifier) == KeyboardModifier.Shift)
-                return true;
+    public static bool IsShiftDown(this KeyboardModifier keyboardModifier)
+    {
+        if ((KeyboardModifier.Shift & keyboardModifier) == KeyboardModifier.Shift)
+            return true;
 
-            return false;
-        }
+        return false;
+    }
 
-        public static bool IsCtrlDown(this KeyboardModifier keyboardModifier)
-        {
-            return (KeyboardModifier.Ctrl & keyboardModifier) == KeyboardModifier.Ctrl;
-        }
+    public static bool IsCtrlDown(this KeyboardModifier keyboardModifier)
+    {
+        return (KeyboardModifier.Ctrl & keyboardModifier) == KeyboardModifier.Ctrl;
+    }
 
-        public static bool IsAltDown(this KeyboardModifier keyboardModifier)
-        {
-            return (KeyboardModifier.Alt & keyboardModifier) == KeyboardModifier.Alt;
-        }
+    public static bool IsAltDown(this KeyboardModifier keyboardModifier)
+    {
+        return (KeyboardModifier.Alt & keyboardModifier) == KeyboardModifier.Alt;
+    }
 
-        /// <summary>
-        /// Returns whether this key is a "modifier" key i.e. control, shift or alt
-        /// </summary>
-        public static bool IsModifierKey(this Keys key)
-        {
-            return IsShift(key) || IsAlt(key) || IsCtrl(key);
-        }
+    /// <summary>
+    /// Returns whether this key is a "modifier" key i.e. control, shift or alt
+    /// </summary>
+    public static bool IsModifierKey(this Keys key)
+    {
+        return IsShift(key) || IsAlt(key) || IsCtrl(key);
+    }
 
-        /// <summary>
-        /// Returns KeyboardModifier object which has shift bit flagged if a shift key was pressed
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns>KeyboardModifier object which has shift bit flagged if a shift key was pressed</returns>
-        public static KeyboardModifier IsShiftModifier(this Keys key)
-        {
-            if (key == Keys.LeftShift || key == Keys.RightShift)
-                return KeyboardModifier.Shift;
+    /// <summary>
+    /// Returns KeyboardModifier object which has shift bit flagged if a shift key was pressed
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns>KeyboardModifier object which has shift bit flagged if a shift key was pressed</returns>
+    public static KeyboardModifier IsShiftModifier(this Keys key)
+    {
+        if (key == Keys.LeftShift || key == Keys.RightShift)
+            return KeyboardModifier.Shift;
 
-            return KeyboardModifier.None;
-        }
+        return KeyboardModifier.None;
+    }
 
-        /// <summary>
-        /// Returns KeyboardModifier object with control key flagged if a control key was pressed
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns>KeyboardModifier object with control key flagged if a control key was pressed</returns>
-        public static KeyboardModifier IsCtrlModifier(this Keys key)
-        {
-            if (key == Keys.LeftControl || key == Keys.RightControl)
-                return KeyboardModifier.Ctrl;
+    /// <summary>
+    /// Returns KeyboardModifier object with control key flagged if a control key was pressed
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns>KeyboardModifier object with control key flagged if a control key was pressed</returns>
+    public static KeyboardModifier IsCtrlModifier(this Keys key)
+    {
+        if (key == Keys.LeftControl || key == Keys.RightControl)
+            return KeyboardModifier.Ctrl;
 
-            return KeyboardModifier.None;
-        }
+        return KeyboardModifier.None;
+    }
 
-        /// <summary>
-        /// Returns KeyboardModifier object with alt key flagged if an alt key is pressed
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns>KeyboardModifier object with alt key flagged if an alt key is pressed</returns>
-        public static KeyboardModifier IsAltModifier(this Keys key)
-        {
-            if (key == Keys.LeftAlt || key == Keys.RightAlt)
-                return KeyboardModifier.Alt;
+    /// <summary>
+    /// Returns KeyboardModifier object with alt key flagged if an alt key is pressed
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns>KeyboardModifier object with alt key flagged if an alt key is pressed</returns>
+    public static KeyboardModifier IsAltModifier(this Keys key)
+    {
+        if (key == Keys.LeftAlt || key == Keys.RightAlt)
+            return KeyboardModifier.Alt;
 
-            return KeyboardModifier.None;
-        }
+        return KeyboardModifier.None;
+    }
 
-        /// <summary>
-        ///     convert the current key into a printable string.  Defaults to any kind of printable character and accounts for
-        ///     shift key.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="keyboardModifier"></param>
-        /// <returns></returns>
-        public static string Display(this Keys key, KeyboardModifier keyboardModifier)
-        {
-            return Display(key, keyboardModifier, true, true, true, false);
-        }
+    /// <summary>
+    ///     convert the current key into a printable string.  Defaults to any kind of printable character and accounts for
+    ///     shift key.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="keyboardModifier"></param>
+    /// <returns></returns>
+    public static string Display(this Keys key, KeyboardModifier keyboardModifier)
+    {
+        return Display(key, keyboardModifier, true, true, true, false);
+    }
 
-        /// <summary>
-        ///     convert the current key into a printable string.  Defaults to alphanumerics on and and accounts for shift key
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="keyboardModifier"></param>
-        /// <param name="selectspecials"></param>
-        /// <returns></returns>
-        public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials)
-        {
-            return Display(key, keyboardModifier, selectspecials, true, true, false);
-        }
+    /// <summary>
+    ///     convert the current key into a printable string.  Defaults to alphanumerics on and and accounts for shift key
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="keyboardModifier"></param>
+    /// <param name="selectspecials"></param>
+    /// <returns></returns>
+    public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials)
+    {
+        return Display(key, keyboardModifier, selectspecials, true, true, false);
+    }
 
-        /// <summary>
-        ///     convert the current key into a printable string given filtering options. Defaults to spaces allowed
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="keyboardModifier"></param>
-        /// <param name="selectspecials">filters so that specials are included in the string if true</param>
-        /// <param name="selectAlphas">filters so that alphas are selected if true</param>
-        /// <param name="selectNumerics">filters so that numerics are selected if true </param>
-        /// <returns></returns>
-        public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials, bool selectAlphas,
-            bool selectNumerics)
-        {
-            return Display(key, keyboardModifier, selectspecials, selectAlphas, selectNumerics, false);
-        }
+    /// <summary>
+    ///     convert the current key into a printable string given filtering options. Defaults to spaces allowed
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="keyboardModifier"></param>
+    /// <param name="selectspecials">filters so that specials are included in the string if true</param>
+    /// <param name="selectAlphas">filters so that alphas are selected if true</param>
+    /// <param name="selectNumerics">filters so that numerics are selected if true </param>
+    /// <returns></returns>
+    public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials, bool selectAlphas,
+        bool selectNumerics)
+    {
+        return Display(key, keyboardModifier, selectspecials, selectAlphas, selectNumerics, false);
+    }
 
-        /// <summary>
-        ///     convert the current key into a printable string.  If users want to force upper case or lower case they can change
-        ///     modifiers m (for example, to enable use of the caps lock key, test it outside the function, if its on pass in a
-        ///     kbmodifiers with shift flag, if off pass KeyboardModifier.None)
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="keyboardModifier"></param>
-        /// <param name="selectspecials">filters so that specials are included in the string if true</param>
-        /// <param name="selectAlphas">filters so that alphas are selected if true</param>
-        /// <param name="selectNumerics">filters so that numerics are selected if true </param>
-        /// <param name="suppressSpace">no spaces are output</param>
-        /// <param name="treatNumpadAsNumeric">treat numpad as numeric keys</param>
-        /// <returns></returns>
-        public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials, bool selectAlphas,
-            bool selectNumerics, bool suppressSpace, bool treatNumpadAsNumeric = true)
-        {
-            if (IsKeySpace(key) && !suppressSpace)
-                return " ";
+    /// <summary>
+    ///     convert the current key into a printable string.  If users want to force upper case or lower case they can change
+    ///     modifiers m (for example, to enable use of the caps lock key, test it outside the function, if its on pass in a
+    ///     kbmodifiers with shift flag, if off pass KeyboardModifier.None)
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="keyboardModifier"></param>
+    /// <param name="selectspecials">filters so that specials are included in the string if true</param>
+    /// <param name="selectAlphas">filters so that alphas are selected if true</param>
+    /// <param name="selectNumerics">filters so that numerics are selected if true </param>
+    /// <param name="suppressSpace">no spaces are output</param>
+    /// <param name="treatNumpadAsNumeric">treat numpad as numeric keys</param>
+    /// <returns></returns>
+    public static string Display(this Keys key, KeyboardModifier keyboardModifier, bool selectspecials, bool selectAlphas,
+        bool selectNumerics, bool suppressSpace, bool treatNumpadAsNumeric = true)
+    {
+        if (IsKeySpace(key) && !suppressSpace)
+            return " ";
 
-            if ((IsKeyAlpha(key) && selectAlphas)
-                || (IsKeyNumber(key) && selectNumerics)
-                || (treatNumpadAsNumeric && IsKeyNumberpad(key) && selectNumerics)
-                || (selectspecials 
-                    && ((!IsKeyAlpha(key) && !IsKeyNumeric(key))
+        if ((IsKeyAlpha(key) && selectAlphas)
+            || (IsKeyNumber(key) && selectNumerics)
+            || (treatNumpadAsNumeric && IsKeyNumberpad(key) && selectNumerics)
+            || (selectspecials 
+                && ((!IsKeyAlpha(key) && !IsKeyNumeric(key))
                     || (IsKeyNumber(key) && IsShiftDown(keyboardModifier)))))
-                if (IsShiftDown(keyboardModifier))
-                {
-                    if (!(!selectspecials && IsKeyNumber(key)))
-                        return shiftedKeys[key.GetHashCode()];
-                }
-                else
-                {
-                    return unshiftedKeys[key.GetHashCode()];
-                }
-
-            return "";
-        }
-
-        /// <summary>
-        /// Gets KeyboardModifier flags indicating which "modifier" keys are down (control, shift, alt)
-        /// </summary>
-        /// <param name="keys">list of keys to test</param>
-        /// <returns>bit field with modifier keys flagged</returns>
-        public static KeyboardModifier GetModifiers(this Keys[] keys)
-        {
-            var keyboardModifier = KeyboardModifier.None;
-
-            foreach (var key in keys)
+            if (IsShiftDown(keyboardModifier))
             {
-                keyboardModifier = keyboardModifier | IsShiftModifier(key);
-                keyboardModifier = keyboardModifier | IsAltModifier(key);
-                keyboardModifier = keyboardModifier | IsCtrlModifier(key);
+                if (!(!selectspecials && IsKeyNumber(key)))
+                    return shiftedKeys[key.GetHashCode()];
+            }
+            else
+            {
+                return unshiftedKeys[key.GetHashCode()];
             }
 
-            return keyboardModifier;
+        return "";
+    }
+
+    /// <summary>
+    /// Gets KeyboardModifier flags indicating which "modifier" keys are down (control, shift, alt)
+    /// </summary>
+    /// <param name="keys">list of keys to test</param>
+    /// <returns>bit field with modifier keys flagged</returns>
+    public static KeyboardModifier GetModifiers(this Keys[] keys)
+    {
+        var keyboardModifier = KeyboardModifier.None;
+
+        foreach (var key in keys)
+        {
+            keyboardModifier = keyboardModifier | IsShiftModifier(key);
+            keyboardModifier = keyboardModifier | IsAltModifier(key);
+            keyboardModifier = keyboardModifier | IsCtrlModifier(key);
         }
 
-        private static readonly string[] unshiftedKeys =
-        {
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", " ", "", "", "", "", "", "", "", //30-39
-            "", "", "", "", "", "", "", "", "0", "1", //40-49
-            "2", "3", "4", "5", "6", "7", "8", "9", "", "", //50-59
-            "", "", "", "", "", "a", "b", "c", "d", "e", //60-69
-            "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", //70-79
-            "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", //80-89
-            "z", "", "", "", "", "", "0", "1", "2", "3", //90-99
-            "4", "5", "6", "7", "8", "9", "*", "+", "", "-", //100-109
-            ".", "/", "", "", "", "", "", "", "", "", //110-119
-            "", "", "", "", "", "", "", "", "", "", //120-129
-            "", "", "", "", "", "", "", "", "", "", //130-139
-            "", "", "", "", "", "", "", "", "", "", //140-149
-            "", "", "", "", "", "", "", "", "", "", //150-159
-            "", "", "", "", "", "", "", "", "", "", //160-169
-            "", "", "", "", "", "", "", "", "", "", //170-179
-            "", "", "", "", "", "", ";", "=", ",", "-", //180-189
-            ".", "/", "`", "", "", "", "", "", "", "", //190-199
-            "", "", "", "", "", "", "", "", "", "", //200-209
-            "", "", "", "", "", "", "", "", "", "[", //210-219
-            "\\", "]", "'", "", "", "", "", "", "", "", //220-229
-            "", "", "", "", "", "", "", "", "", "", //230-239
-            "", "", "", "", "", "", "", "", "", "", //240-249
-            "", "", "", "", "", ""
-        }; //250-255
-
-        private static readonly string[] shiftedKeys =
-        {
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", "", "", "", "", "", "", "", "",
-            "", "", " ", "", "", "", "", "", "", "", //30-39
-            "", "", "", "", "", "", "", "", ")", "!", //40-49
-            "@", "#", "$", "%", "^", "&", "*", "(", "", "", //50-59
-            "", "", "", "", "", "A", "B", "C", "D", "E", //60-69
-            "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", //70-79
-            "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", //80-89
-            "Z", "", "", "", "", "", "", "", "", "", //90-99
-            "", "", "", "", "", "", "*", "+", "", "-", //100-109
-            ".", "/", "", "", "", "", "", "", "", "", //110-119
-            "", "", "", "", "", "", "", "", "", "", //120-129
-            "", "", "", "", "", "", "", "", "", "", //130-139
-            "", "", "", "", "", "", "", "", "", "", //140-149
-            "", "", "", "", "", "", "", "", "", "", //150-159
-            "", "", "", "", "", "", "", "", "", "", //160-169
-            "", "", "", "", "", "", "", "", "", "", //170-179
-            "", "", "", "", "", "", ":", "+", "<", "_", //180-189
-            ">", "?", "~", "", "", "", "", "", "", "", //190-199
-            "", "", "", "", "", "", "", "", "", "", //200-209
-            "", "", "", "", "", "", "", "", "", "{", //210-219
-            "|", "}", "\"", "", "", "", "", "", "", "", //220-229
-            "", "", "", "", "", "", "", "", "", "", //230-239
-            "", "", "", "", "", "", "", "", "", "", //240-249
-            "", "", "", "", "", ""
-        }; //250-255
+        return keyboardModifier;
     }
+
+    private static readonly string[] unshiftedKeys =
+    {
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", " ", "", "", "", "", "", "", "", //30-39
+        "", "", "", "", "", "", "", "", "0", "1", //40-49
+        "2", "3", "4", "5", "6", "7", "8", "9", "", "", //50-59
+        "", "", "", "", "", "a", "b", "c", "d", "e", //60-69
+        "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", //70-79
+        "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", //80-89
+        "z", "", "", "", "", "", "0", "1", "2", "3", //90-99
+        "4", "5", "6", "7", "8", "9", "*", "+", "", "-", //100-109
+        ".", "/", "", "", "", "", "", "", "", "", //110-119
+        "", "", "", "", "", "", "", "", "", "", //120-129
+        "", "", "", "", "", "", "", "", "", "", //130-139
+        "", "", "", "", "", "", "", "", "", "", //140-149
+        "", "", "", "", "", "", "", "", "", "", //150-159
+        "", "", "", "", "", "", "", "", "", "", //160-169
+        "", "", "", "", "", "", "", "", "", "", //170-179
+        "", "", "", "", "", "", ";", "=", ",", "-", //180-189
+        ".", "/", "`", "", "", "", "", "", "", "", //190-199
+        "", "", "", "", "", "", "", "", "", "", //200-209
+        "", "", "", "", "", "", "", "", "", "[", //210-219
+        "\\", "]", "'", "", "", "", "", "", "", "", //220-229
+        "", "", "", "", "", "", "", "", "", "", //230-239
+        "", "", "", "", "", "", "", "", "", "", //240-249
+        "", "", "", "", "", ""
+    }; //250-255
+
+    private static readonly string[] shiftedKeys =
+    {
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "", "", "",
+        "", "", " ", "", "", "", "", "", "", "", //30-39
+        "", "", "", "", "", "", "", "", ")", "!", //40-49
+        "@", "#", "$", "%", "^", "&", "*", "(", "", "", //50-59
+        "", "", "", "", "", "A", "B", "C", "D", "E", //60-69
+        "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", //70-79
+        "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", //80-89
+        "Z", "", "", "", "", "", "", "", "", "", //90-99
+        "", "", "", "", "", "", "*", "+", "", "-", //100-109
+        ".", "/", "", "", "", "", "", "", "", "", //110-119
+        "", "", "", "", "", "", "", "", "", "", //120-129
+        "", "", "", "", "", "", "", "", "", "", //130-139
+        "", "", "", "", "", "", "", "", "", "", //140-149
+        "", "", "", "", "", "", "", "", "", "", //150-159
+        "", "", "", "", "", "", "", "", "", "", //160-169
+        "", "", "", "", "", "", "", "", "", "", //170-179
+        "", "", "", "", "", "", ":", "+", "<", "_", //180-189
+        ">", "?", "~", "", "", "", "", "", "", "", //190-199
+        "", "", "", "", "", "", "", "", "", "", //200-209
+        "", "", "", "", "", "", "", "", "", "{", //210-219
+        "|", "}", "\"", "", "", "", "", "", "", "", //220-229
+        "", "", "", "", "", "", "", "", "", "", //230-239
+        "", "", "", "", "", "", "", "", "", "", //240-249
+        "", "", "", "", "", ""
+    }; //250-255
 }

--- a/InputHandlers/MouseHandlerSubscription.cs
+++ b/InputHandlers/MouseHandlerSubscription.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace InputHandlers.Mouse;
+
+public class MouseHandlerSubscription
+{
+    protected bool Equals(MouseHandlerSubscription other)
+    {
+        return Equals(_mouseHandler, other._mouseHandler);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((MouseHandlerSubscription)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return (_mouseHandler != null ? _mouseHandler.GetHashCode() : 0);
+    }
+
+    public IMouseHandler MouseHandler => _mouseHandler;
+    private readonly IMouseHandler _mouseHandler;
+
+    public TimeSpan SubscribedTime => _subscribedTime;
+    private TimeSpan _subscribedTime;
+
+    public MouseHandlerSubscription(IMouseHandler mouseHandler, IStopwatchProvider stopwatchProvider)
+    {
+        _mouseHandler = mouseHandler;
+        _subscribedTime = stopwatchProvider.Elapsed;
+    }
+
+    public void UpdateSubscribedTime(IStopwatchProvider stopwatchProvider)
+    {
+        _subscribedTime = stopwatchProvider.Elapsed;
+    }
+}

--- a/InputHandlers/MouseInput.cs
+++ b/InputHandlers/MouseInput.cs
@@ -8,605 +8,629 @@ using InputHandlers.StateMachine;
 
 using Microsoft.Xna.Framework.Input;
 
-namespace InputHandlers.Mouse
+namespace InputHandlers.Mouse;
+
+public class MouseInput : IMouseInput
 {
-    public class MouseInput : IMouseInput
+    private readonly StateMachine<MouseInput> _mouseStateMachine;
+    private readonly MouseStationaryState _mouseStationaryState = new MouseStationaryState();
+    private readonly MouseMovingState _mouseMovingState = new MouseMovingState();
+    private readonly MouseLeftDownState _mouseLeftDownState = new MouseLeftDownState();
+    private readonly MouseLeftDraggingState _mouseLeftDraggingState = new MouseLeftDraggingState();
+    private readonly MouseRightDownState _mouseRightDownState = new MouseRightDownState();
+    private readonly MouseRightDraggingState _mouseRightDraggingState = new MouseRightDraggingState();
+    private readonly MouseMiddleDownState _mouseMiddleDownState = new MouseMiddleDownState();
+    private readonly MouseMiddleDraggingState _mouseMiddleDraggingState = new MouseMiddleDraggingState();
+    private readonly HashSet<IMouseHandler> _mouseHandlerSubscriptions = new HashSet<IMouseHandler>();
+    private readonly HashSet<MouseHandlerSubscription> _pendingAddedSubscriptions = new HashSet<MouseHandlerSubscription>();
+    private readonly HashSet<MouseHandlerSubscription> _pendingRemovedSubscriptions = new HashSet<MouseHandlerSubscription>();
+
+    public MouseState OldMouseState { get; private set; }
+    public MouseState CurrentMouseState { get; private set; }
+    public MouseState DragOriginPosition { get; private set; }
+    public IStopwatchProvider StopwatchProvider { get; private set; }
+    public bool IsLeftButtonEnabled { get; set; } = true;
+    public bool IsMiddleButtonEnabled { get; set; } = true;
+    public bool IsRightButtonEnabled { get; set; } = true;
+
+    /// <summary>
+    /// DragVariance is a fudging factor for detecting the difference between mouse clicks and mouse drags.
+    /// This is because a fast user may do a mouse click while slightly moving the mouse between mouse down and mouse up.
+    /// If it wasnt for this fudging factor then it would go into drag mode which isnt what the user probably wanted.
+    /// </summary>
+    public int DragVariance { get; set; } = 10;
+
+    /// <summary>
+    /// If time between clicks in milliseconds is less than this value then it is considered a double click
+    /// </summary>
+    public int DoubleClickDetectionTimeDelay { get; set; } = 400;
+
+    /// <summary>
+    /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
+    /// </summary>
+    public int UpdateNumber { get; private set; }
+        
+    /// <summary>
+    /// Whether to wait for a neutral mouse state before applying pending subscriptions. Old subscriptions are still removed immediately. Defaults to False.
+    /// </summary>
+    public bool WaitForNeutralStateBeforeApplyingNewSubscriptions { get; set; }
+
+    public MouseInput() : this(new StopwatchProvider())
     {
-        private readonly StateMachine<MouseInput> _mouseStateMachine;
-        private readonly MouseStationaryState _mouseStationaryState = new MouseStationaryState();
-        private readonly MouseMovingState _mouseMovingState = new MouseMovingState();
-        private readonly MouseLeftDownState _mouseLeftDownState = new MouseLeftDownState();
-        private readonly MouseLeftDraggingState _mouseLeftDraggingState = new MouseLeftDraggingState();
-        private readonly MouseRightDownState _mouseRightDownState = new MouseRightDownState();
-        private readonly MouseRightDraggingState _mouseRightDraggingState = new MouseRightDraggingState();
-        private readonly MouseMiddleDownState _mouseMiddleDownState = new MouseMiddleDownState();
-        private readonly MouseMiddleDraggingState _mouseMiddleDraggingState = new MouseMiddleDraggingState();
-        private readonly HashSet<IMouseHandler> _mouseHandlerSubscriptions = new HashSet<IMouseHandler>();
-        private readonly HashSet<IMouseHandler> _pendingAddedSubscriptions = new HashSet<IMouseHandler>();
-        private readonly HashSet<IMouseHandler> _pendingRemovedSubscriptions = new HashSet<IMouseHandler>();
+    }
 
-        public MouseState OldMouseState { get; private set; }
-        public MouseState CurrentMouseState { get; private set; }
-        public MouseState DragOriginPosition { get; private set; }
-        public IStopwatchProvider StopwatchProvider { get; private set; }
-        public bool IsLeftButtonEnabled { get; set; } = true;
-        public bool IsMiddleButtonEnabled { get; set; } = true;
-        public bool IsRightButtonEnabled { get; set; } = true;
+    public MouseInput(IStopwatchProvider stopwatchProvider)
+    {
+        StopwatchProvider = stopwatchProvider;
+        StopwatchProvider.Start();
 
-        /// <summary>
-        /// DragVariance is a fudging factor for detecting the difference between mouse clicks and mouse drags.
-        /// This is because a fast user may do a mouse click while slightly moving the mouse between mouse down and mouse up.
-        /// If it wasnt for this fudging factor then it would go into drag mode which isnt what the user probably wanted.
-        /// </summary>
-        public int DragVariance { get; set; } = 10;
+        _mouseStateMachine = new StateMachine<MouseInput>(this);
+        _mouseStateMachine.SetCurrentState(_mouseStationaryState);
+        _mouseStateMachine.SetPreviousState(_mouseStationaryState);
+    }
 
-        /// <summary>
-        /// If time between clicks in milliseconds is less than this value then it is considered a double click
-        /// </summary>
-        public int DoubleClickDetectionTimeDelay { get; set; } = 400;
+    public void Subscribe(IMouseHandler mouseHandler)
+    {
+        var existingSubscription = _pendingAddedSubscriptions.SingleOrDefault(s => s.MouseHandler.Equals(mouseHandler));
+            
+        if (existingSubscription != null)
+            existingSubscription.UpdateSubscribedTime(StopwatchProvider);
+        else
+            _pendingAddedSubscriptions.Add(new MouseHandlerSubscription(mouseHandler, StopwatchProvider));
+    }
 
-        /// <summary>
-        /// This is incremented on each update.  This can be used to determine whether a sequence of events have occurred within the same update time. 
-        /// </summary>
-        public int UpdateNumber { get; private set; }
+    public void Unsubscribe(IMouseHandler mouseHandler)
+    {
+        var existingSubscription = _pendingRemovedSubscriptions.SingleOrDefault(s => s.MouseHandler.Equals(mouseHandler));
+            
+        if (existingSubscription != null)
+            existingSubscription.UpdateSubscribedTime(StopwatchProvider);
+        else
+            _pendingRemovedSubscriptions.Add(new MouseHandlerSubscription(mouseHandler, StopwatchProvider));
+    }
 
-        public MouseInput() : this(new StopwatchProvider())
+    private void CallHandleMouseScrollWheelMove(MouseState m, int diff)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
+            mouseHandler.HandleMouseScrollWheelMove(m, diff);
         }
+    }
 
-        public MouseInput(IStopwatchProvider stopwatchProvider)
+    private void CallHandleMouseMoving(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            StopwatchProvider = stopwatchProvider;
-            StopwatchProvider.Start();
-
-            _mouseStateMachine = new StateMachine<MouseInput>(this);
-            _mouseStateMachine.SetCurrentState(_mouseStationaryState);
-            _mouseStateMachine.SetPreviousState(_mouseStationaryState);
+            mouseHandler.HandleMouseMoving(m, origin);
         }
+    }
 
-        public void Subscribe(IMouseHandler mouseHandler)
+    private void CallHandleLeftMouseClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            if (mouseHandler != null)
-                _pendingAddedSubscriptions.Add(mouseHandler);
+            mouseHandler.HandleLeftMouseClick(m, origin);
         }
+    }
 
-        public void Unsubscribe(IMouseHandler mouseHandler)
+    private void CallHandleLeftMouseDoubleClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            if (mouseHandler != null)
-                _pendingRemovedSubscriptions.Add(mouseHandler);
+            mouseHandler.HandleLeftMouseDoubleClick(m, origin);
         }
+    }
 
-        private void CallHandleMouseScrollWheelMove(MouseState m, int diff)
+    private void CallHandleLeftMouseDown(MouseState m)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMouseScrollWheelMove(m, diff);
-            }
+            mouseHandler.HandleLeftMouseDown(m);
         }
+    }
 
-        private void CallHandleMouseMoving(MouseState m, MouseState origin)
+    private void CallHandleLeftMouseUp(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMouseMoving(m, origin);
-            }
+            mouseHandler.HandleLeftMouseUp(m, origin);
         }
+    }
 
-        private void CallHandleLeftMouseClick(MouseState m, MouseState origin)
+    private void CallHandleLeftMouseDragging(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseClick(m, origin);
-            }
+            mouseHandler.HandleLeftMouseDragging(m, origin);
         }
+    }
 
-        private void CallHandleLeftMouseDoubleClick(MouseState m, MouseState origin)
+    private void CallHandleLeftMouseDragDone(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseDoubleClick(m, origin);
-            }
+            mouseHandler.HandleLeftMouseDragDone(m, origin);
         }
+    }
 
-        private void CallHandleLeftMouseDown(MouseState m)
+    private void CallHandleRightMouseClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseDown(m);
-            }
+            mouseHandler.HandleRightMouseClick(m, origin);
         }
+    }
 
-        private void CallHandleLeftMouseUp(MouseState m, MouseState origin)
+    private void CallHandleRightMouseDoubleClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseUp(m, origin);
-            }
+            mouseHandler.HandleRightMouseDoubleClick(m, origin);
         }
+    }
 
-        private void CallHandleLeftMouseDragging(MouseState m, MouseState origin)
+    private void CallHandleRightMouseDown(MouseState m)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseDragging(m, origin);
-            }
+            mouseHandler.HandleRightMouseDown(m);
         }
+    }
 
-        private void CallHandleLeftMouseDragDone(MouseState m, MouseState origin)
+    private void CallHandleRightMouseUp(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleLeftMouseDragDone(m, origin);
-            }
+            mouseHandler.HandleRightMouseUp(m, origin);
         }
+    }
 
-        private void CallHandleRightMouseClick(MouseState m, MouseState origin)
+    private void CallHandleRightMouseDragging(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseClick(m, origin);
-            }
+            mouseHandler.HandleRightMouseDragging(m, origin);
         }
+    }
 
-        private void CallHandleRightMouseDoubleClick(MouseState m, MouseState origin)
+    private void CallHandleRightMouseDragDone(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseDoubleClick(m, origin);
-            }
+            mouseHandler.HandleRightMouseDragDone(m, origin);
         }
+    }
 
-        private void CallHandleRightMouseDown(MouseState m)
+    private void CallHandleMiddleMouseClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseDown(m);
-            }
+            mouseHandler.HandleMiddleMouseClick(m, origin);
         }
+    }
 
-        private void CallHandleRightMouseUp(MouseState m, MouseState origin)
+    private void CallHandleMiddleMouseDoubleClick(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseUp(m, origin);
-            }
+            mouseHandler.HandleMiddleMouseDoubleClick(m, origin);
         }
+    }
 
-        private void CallHandleRightMouseDragging(MouseState m, MouseState origin)
+    private void CallHandleMiddleMouseDown(MouseState m)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseDragging(m, origin);
-            }
+            mouseHandler.HandleMiddleMouseDown(m);
         }
+    }
 
-        private void CallHandleRightMouseDragDone(MouseState m, MouseState origin)
+    private void CallHandleMiddleMouseUp(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleRightMouseDragDone(m, origin);
-            }
+            mouseHandler.HandleMiddleMouseUp(m, origin);
         }
+    }
 
-        private void CallHandleMiddleMouseClick(MouseState m, MouseState origin)
+    private void CallHandleMiddleMouseDragging(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseClick(m, origin);
-            }
+            mouseHandler.HandleMiddleMouseDragging(m, origin);
         }
+    }
 
-        private void CallHandleMiddleMouseDoubleClick(MouseState m, MouseState origin)
+    private void CallHandleMiddleMouseDragDone(MouseState m, MouseState origin)
+    {
+        foreach (var mouseHandler in _mouseHandlerSubscriptions)
         {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseDoubleClick(m, origin);
-            }
+            mouseHandler.HandleMiddleMouseDragDone(m, origin);
         }
+    }
 
-        private void CallHandleMiddleMouseDown(MouseState m)
-        {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseDown(m);
-            }
-        }
+    /// <summary>
+    /// Poll the mouse for updates.
+    /// </summary>
+    /// <param name="mouseState">a mouse state.  You should use the XNA input function, Mouse.GetState(), as this parameter.</param>
+    public void Poll(MouseState mouseState)
+    {
+        UpdateNumber++;
 
-        private void CallHandleMiddleMouseUp(MouseState m, MouseState origin)
-        {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseUp(m, origin);
-            }
-        }
-
-        private void CallHandleMiddleMouseDragging(MouseState m, MouseState origin)
-        {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseDragging(m, origin);
-            }
-        }
-
-        private void CallHandleMiddleMouseDragDone(MouseState m, MouseState origin)
-        {
-            foreach (var mouseHandler in _mouseHandlerSubscriptions)
-            {
-                mouseHandler.HandleMiddleMouseDragDone(m, origin);
-            }
-        }
-
-        /// <summary>
-        /// Poll the mouse for updates.
-        /// </summary>
-        /// <param name="mouseState">a mouse state.  You should use the XNA input function, Mouse.GetState(), as this parameter.</param>
-        public void Poll(MouseState mouseState)
-        {
-            UpdateNumber++;
-
-            if (UpdateNumber == int.MaxValue)
-                UpdateNumber = 0;
-
-            OldMouseState = CurrentMouseState;
-            CurrentMouseState = mouseState;
-
-            CheckScrollWheel();
-
-            UpdateSubscriptions();
-
-            _mouseStateMachine.Update();
-        }
-
-        private void UpdateSubscriptions()
-        {
-            foreach (var pendingAddedSubscription in _pendingAddedSubscriptions)
-                _mouseHandlerSubscriptions.Add(pendingAddedSubscription);
-
-            foreach (var pendingRemovedSubscriptions in _pendingRemovedSubscriptions)
-                _mouseHandlerSubscriptions.Remove(pendingRemovedSubscriptions);
-
-            _pendingAddedSubscriptions.Clear();
-            _pendingRemovedSubscriptions.Clear();
-        }
-
-        /// <summary>
-        /// Reset to stationary state.  You may wish to call this when, for example, switching interface screens.
-        /// </summary>
-        public void Reset()
-        {
-            StopwatchProvider.Stop();
-            StopwatchProvider.Reset();
-            StopwatchProvider.Start();
+        if (UpdateNumber == int.MaxValue)
             UpdateNumber = 0;
-            _mouseStateMachine.CurrentState.Reset(this);
-            _mouseStateMachine.SetCurrentState(_mouseStationaryState);
-            _mouseStateMachine.SetPreviousState(_mouseStationaryState);
-        }
 
-        public string CurrentStateAsString()
+        OldMouseState = CurrentMouseState;
+        CurrentMouseState = mouseState;
+
+        CheckScrollWheel();
+
+        UpdateSubscriptions();
+
+        _mouseStateMachine.Update();
+    }
+
+    private void UpdateSubscriptions()
+    {
+        foreach (var pendingRemovedSubscription in _pendingRemovedSubscriptions)
         {
-            return _mouseStateMachine.GetCurrentStateTypeName();
+            _mouseHandlerSubscriptions.Remove(pendingRemovedSubscription.MouseHandler);
+
+            var addedSubscription =
+                _pendingAddedSubscriptions.SingleOrDefault(s => s.Equals(pendingRemovedSubscription));
+
+            if (addedSubscription != null && pendingRemovedSubscription.SubscribedTime >= addedSubscription.SubscribedTime)
+                _pendingAddedSubscriptions.Remove(addedSubscription);
         }
+            
+        _pendingRemovedSubscriptions.Clear();
 
-        private void CheckScrollWheel()
+        if (WaitForNeutralStateBeforeApplyingNewSubscriptions && _mouseStateMachine.CurrentState is not MouseStationaryState)
+            return;
+            
+        foreach (var pendingAddedSubscription in _pendingAddedSubscriptions)
+            _mouseHandlerSubscriptions.Add(pendingAddedSubscription.MouseHandler);
+
+        _pendingAddedSubscriptions.Clear();
+    }
+        
+    /// <summary>
+    /// Reset to stationary state.  You may wish to call this when, for example, switching interface screens.
+    /// </summary>
+    public void Reset()
+    {
+        StopwatchProvider.Stop();
+        StopwatchProvider.Reset();
+        StopwatchProvider.Start();
+        UpdateNumber = 0;
+        _mouseStateMachine.CurrentState.Reset(this);
+        _mouseStateMachine.SetCurrentState(_mouseStationaryState);
+        _mouseStateMachine.SetPreviousState(_mouseStationaryState);
+    }
+
+    public string CurrentStateAsString()
+    {
+        return _mouseStateMachine.GetCurrentStateTypeName();
+    }
+
+    private void CheckScrollWheel()
+    {
+        var diff = CurrentMouseState.ScrollWheelValue - OldMouseState.ScrollWheelValue;
+
+        if (diff != 0)
+            CallHandleMouseScrollWheelMove(CurrentMouseState, diff);
+    }
+
+    private bool IsStartingDragDrop()
+    {
+        return (Math.Abs(DragOriginPosition.X - CurrentMouseState.X) > DragVariance) ||
+               (Math.Abs(DragOriginPosition.Y - CurrentMouseState.Y) > DragVariance);
+    }
+
+    private abstract class MouseUnpressedButtonState : State<MouseInput>
+    {
+        protected bool TryChangeStateForButtons(MouseInput mouseInput)
         {
-            var diff = CurrentMouseState.ScrollWheelValue - OldMouseState.ScrollWheelValue;
-
-            if (diff != 0)
-                CallHandleMouseScrollWheelMove(CurrentMouseState, diff);
-        }
-
-        private bool IsStartingDragDrop()
-        {
-            return (Math.Abs(DragOriginPosition.X - CurrentMouseState.X) > DragVariance) ||
-                   (Math.Abs(DragOriginPosition.Y - CurrentMouseState.Y) > DragVariance);
-        }
-
-        private abstract class MouseUnpressedButtonState : State<MouseInput>
-        {
-            protected bool TryChangeStateForButtons(MouseInput mouseInput)
+            if (mouseInput.IsLeftButtonEnabled && mouseInput.CurrentMouseState.LeftButton == ButtonState.Pressed)
             {
-                if (mouseInput.IsLeftButtonEnabled && mouseInput.CurrentMouseState.LeftButton == ButtonState.Pressed)
-                {
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseLeftDownState);
-                    return true;
-                }
-
-                if (mouseInput.IsRightButtonEnabled && mouseInput.CurrentMouseState.RightButton == ButtonState.Pressed)
-                {
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseRightDownState);
-                    return true;
-                }
-
-                if (mouseInput.IsMiddleButtonEnabled && mouseInput.CurrentMouseState.MiddleButton == ButtonState.Pressed)
-                {
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseMiddleDownState);
-                    return true;
-                }
-
-                return false;
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseLeftDownState);
+                return true;
             }
+
+            if (mouseInput.IsRightButtonEnabled && mouseInput.CurrentMouseState.RightButton == ButtonState.Pressed)
+            {
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseRightDownState);
+                return true;
+            }
+
+            if (mouseInput.IsMiddleButtonEnabled && mouseInput.CurrentMouseState.MiddleButton == ButtonState.Pressed)
+            {
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseMiddleDownState);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private class MouseStationaryState : MouseUnpressedButtonState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
         }
 
-        private class MouseStationaryState : MouseUnpressedButtonState
+        public override void Execute(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-            }
+            if (TryChangeStateForButtons(mouseInput))
+                return;
 
-            public override void Execute(MouseInput mouseInput)
-            {
-                if (TryChangeStateForButtons(mouseInput))
-                    return;
-
-                if (mouseInput.CurrentMouseState.X != mouseInput.OldMouseState.X || mouseInput.CurrentMouseState.Y != mouseInput.OldMouseState.Y)
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseMovingState);
-            }
-
-            public override void Exit(MouseInput mouseInput)
-            {
-            }
-
-            public override void Reset(MouseInput mouseInput)
-            {
-            }
+            if (mouseInput.CurrentMouseState.X != mouseInput.OldMouseState.X || mouseInput.CurrentMouseState.Y != mouseInput.OldMouseState.Y)
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseMovingState);
         }
 
-        private class MouseMovingState : MouseUnpressedButtonState
+        public override void Exit(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
+        }
+
+        public override void Reset(MouseInput mouseInput)
+        {
+        }
+    }
+
+    private class MouseMovingState : MouseUnpressedButtonState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            mouseInput.CallHandleMouseMoving(mouseInput.CurrentMouseState, mouseInput.OldMouseState);
+        }
+
+        public override void Execute(MouseInput mouseInput)
+        {
+            if (TryChangeStateForButtons(mouseInput))
+                return;
+
+            if (mouseInput.CurrentMouseState.X == mouseInput.OldMouseState.X && mouseInput.CurrentMouseState.Y == mouseInput.OldMouseState.Y)
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
+            else
                 mouseInput.CallHandleMouseMoving(mouseInput.CurrentMouseState, mouseInput.OldMouseState);
-            }
-
-            public override void Execute(MouseInput mouseInput)
-            {
-                if (TryChangeStateForButtons(mouseInput))
-                    return;
-
-                if (mouseInput.CurrentMouseState.X == mouseInput.OldMouseState.X && mouseInput.CurrentMouseState.Y == mouseInput.OldMouseState.Y)
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
-                else
-                    mouseInput.CallHandleMouseMoving(mouseInput.CurrentMouseState, mouseInput.OldMouseState);
-            }
-
-            public override void Exit(MouseInput mouseInput)
-            {
-            }
-
-            public override void Reset(MouseInput mouseInput)
-            {
-            }
         }
 
-        private abstract class MouseButtonDownState : State<MouseInput>
+        public override void Exit(MouseInput mouseInput)
         {
-            private double _detectDoubleClickTime;
-            private bool _wasDoubleClickDone;
+        }
 
-            public MouseButtonDownState()
+        public override void Reset(MouseInput mouseInput)
+        {
+        }
+    }
+
+    private abstract class MouseButtonDownState : State<MouseInput>
+    {
+        private double _detectDoubleClickTime;
+        private bool _wasDoubleClickDone;
+
+        public MouseButtonDownState()
+        {
+            _detectDoubleClickTime = double.NegativeInfinity;
+            _wasDoubleClickDone = false;
+        }
+
+        protected void EnterInternal(
+            MouseInput mouseInput,
+            Action<MouseState> mouseDownAction,
+            Action<MouseState, MouseState> mouseDoubleClickAction)
+        {
+            mouseInput.DragOriginPosition = mouseInput.CurrentMouseState;
+
+            if (double.IsNegativeInfinity(_detectDoubleClickTime))
             {
-                _detectDoubleClickTime = double.NegativeInfinity;
-                _wasDoubleClickDone = false;
+                _detectDoubleClickTime = mouseInput.StopwatchProvider.Elapsed.TotalMilliseconds;
+                mouseDownAction(mouseInput.CurrentMouseState);
             }
-
-            protected void EnterInternal(
-                MouseInput mouseInput,
-                Action<MouseState> mouseDownAction,
-                Action<MouseState, MouseState> mouseDoubleClickAction)
+            else
             {
-                mouseInput.DragOriginPosition = mouseInput.CurrentMouseState;
+                _detectDoubleClickTime -= mouseInput.StopwatchProvider.Elapsed.TotalMilliseconds;
 
-                if (double.IsNegativeInfinity(_detectDoubleClickTime))
+                if (_detectDoubleClickTime >= -mouseInput.DoubleClickDetectionTimeDelay)
+                {
+                    mouseDoubleClickAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+
+                    _detectDoubleClickTime = double.NegativeInfinity;
+
+                    _wasDoubleClickDone = true;
+                }
+                else
                 {
                     _detectDoubleClickTime = mouseInput.StopwatchProvider.Elapsed.TotalMilliseconds;
                     mouseDownAction(mouseInput.CurrentMouseState);
                 }
-                else
-                {
-                    _detectDoubleClickTime -= mouseInput.StopwatchProvider.Elapsed.TotalMilliseconds;
-
-                    if (_detectDoubleClickTime >= -mouseInput.DoubleClickDetectionTimeDelay)
-                    {
-                        mouseDoubleClickAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-
-                        _detectDoubleClickTime = double.NegativeInfinity;
-
-                        _wasDoubleClickDone = true;
-                    }
-                    else
-                    {
-                        _detectDoubleClickTime = mouseInput.StopwatchProvider.Elapsed.TotalMilliseconds;
-                        mouseDownAction(mouseInput.CurrentMouseState);
-                    }
-                }
-            }
-
-            protected void ExecuteInternal(
-                MouseInput mouseInput,
-                Action<MouseState, MouseState> mouseUpAction,
-                Action<MouseState, MouseState> mouseClickAction,
-                State<MouseInput> draggingState,
-                ButtonState buttonState
-                )
-            {
-                if (_wasDoubleClickDone)
-                {
-                    if (buttonState == ButtonState.Released)
-                    {
-                        _wasDoubleClickDone = false;
-                        mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
-                    }
-                }
-                else if (buttonState == ButtonState.Released)
-                {
-                    mouseUpAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-                    mouseClickAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-                    mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
-                }
-                else if (mouseInput.IsStartingDragDrop())
-                {
-                    mouseInput._mouseStateMachine.ChangeState(draggingState);
-                }
-            }
-
-            public override void Exit(MouseInput mouseInput)
-            {
-            }
-
-            public override void Reset(MouseInput mouseInput)
-            {
-                _detectDoubleClickTime = double.NegativeInfinity;
-                _wasDoubleClickDone = false;
             }
         }
 
-        private abstract class MouseDraggingState : State<MouseInput>
+        protected void ExecuteInternal(
+            MouseInput mouseInput,
+            Action<MouseState, MouseState> mouseUpAction,
+            Action<MouseState, MouseState> mouseClickAction,
+            State<MouseInput> draggingState,
+            ButtonState buttonState
+        )
         {
-            protected void EnterInternal(
-                MouseInput mouseInput,
-                Action<MouseState, MouseState> mouseDraggingAction
-                )
-            {
-                mouseDraggingAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-            }
-
-            protected void ExecuteInternal(
-                MouseInput mouseInput,
-                Action<MouseState, MouseState> mouseUpAction,
-                Action<MouseState, MouseState> mouseDragging,
-                Action<MouseState, MouseState> mouseDragDone,
-                ButtonState buttonState
-                )
+            if (_wasDoubleClickDone)
             {
                 if (buttonState == ButtonState.Released)
                 {
-                    mouseUpAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-                    mouseDragDone(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+                    _wasDoubleClickDone = false;
                     mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
                 }
-                else if ((mouseInput.CurrentMouseState.X != mouseInput.OldMouseState.X) || (mouseInput.CurrentMouseState.Y != mouseInput.OldMouseState.Y))
-                {
-                    mouseDragging(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
-                }
             }
-
-            public override void Exit(MouseInput mouseInput)
+            else if (buttonState == ButtonState.Released)
             {
+                mouseUpAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+                mouseClickAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
             }
-
-            public override void Reset(MouseInput mouseInput)
+            else if (mouseInput.IsStartingDragDrop())
             {
+                mouseInput._mouseStateMachine.ChangeState(draggingState);
             }
         }
 
-        private class MouseLeftDownState : MouseButtonDownState
+        public override void Exit(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleLeftMouseDown, mouseInput.CallHandleLeftMouseDoubleClick);
-            }
+        }
 
-            public override void Execute(MouseInput mouseInput)
+        public override void Reset(MouseInput mouseInput)
+        {
+            _detectDoubleClickTime = double.NegativeInfinity;
+            _wasDoubleClickDone = false;
+        }
+    }
+
+    private abstract class MouseDraggingState : State<MouseInput>
+    {
+        protected void EnterInternal(
+            MouseInput mouseInput,
+            Action<MouseState, MouseState> mouseDraggingAction
+        )
+        {
+            mouseDraggingAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+        }
+
+        protected void ExecuteInternal(
+            MouseInput mouseInput,
+            Action<MouseState, MouseState> mouseUpAction,
+            Action<MouseState, MouseState> mouseDragging,
+            Action<MouseState, MouseState> mouseDragDone,
+            ButtonState buttonState
+        )
+        {
+            if (buttonState == ButtonState.Released)
             {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleLeftMouseUp,
-                    mouseInput.CallHandleLeftMouseClick,
-                    mouseInput._mouseLeftDraggingState,
-                    mouseInput.CurrentMouseState.LeftButton);
+                mouseUpAction(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+                mouseDragDone(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
+                mouseInput._mouseStateMachine.ChangeState(mouseInput._mouseStationaryState);
+            }
+            else if ((mouseInput.CurrentMouseState.X != mouseInput.OldMouseState.X) || (mouseInput.CurrentMouseState.Y != mouseInput.OldMouseState.Y))
+            {
+                mouseDragging(mouseInput.CurrentMouseState, mouseInput.DragOriginPosition);
             }
         }
 
-        private class MouseLeftDraggingState : MouseDraggingState
+        public override void Exit(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleLeftMouseDragging);
-            }
-
-            public override void Execute(MouseInput mouseInput)
-            {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleLeftMouseUp,
-                    mouseInput.CallHandleLeftMouseDragging,
-                    mouseInput.CallHandleLeftMouseDragDone,
-                    mouseInput.CurrentMouseState.LeftButton);
-            }
         }
 
-        private class MouseRightDownState : MouseButtonDownState
+        public override void Reset(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleRightMouseDown, mouseInput.CallHandleRightMouseDoubleClick);
-            }
+        }
+    }
 
-            public override void Execute(MouseInput mouseInput)
-            {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleRightMouseUp,
-                    mouseInput.CallHandleRightMouseClick,
-                    mouseInput._mouseRightDraggingState,
-                    mouseInput.CurrentMouseState.RightButton);
-            }
+    private class MouseLeftDownState : MouseButtonDownState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleLeftMouseDown, mouseInput.CallHandleLeftMouseDoubleClick);
         }
 
-        private class MouseRightDraggingState : MouseDraggingState
+        public override void Execute(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleRightMouseDragging);
-            }
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleLeftMouseUp,
+                mouseInput.CallHandleLeftMouseClick,
+                mouseInput._mouseLeftDraggingState,
+                mouseInput.CurrentMouseState.LeftButton);
+        }
+    }
 
-            public override void Execute(MouseInput mouseInput)
-            {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleRightMouseUp,
-                    mouseInput.CallHandleRightMouseDragging,
-                    mouseInput.CallHandleRightMouseDragDone,
-                    mouseInput.CurrentMouseState.RightButton);
-            }
+    private class MouseLeftDraggingState : MouseDraggingState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleLeftMouseDragging);
         }
 
-        private class MouseMiddleDownState : MouseButtonDownState
+        public override void Execute(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleMiddleMouseDown, mouseInput.CallHandleMiddleMouseDoubleClick);
-            }
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleLeftMouseUp,
+                mouseInput.CallHandleLeftMouseDragging,
+                mouseInput.CallHandleLeftMouseDragDone,
+                mouseInput.CurrentMouseState.LeftButton);
+        }
+    }
 
-            public override void Execute(MouseInput mouseInput)
-            {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleMiddleMouseUp,
-                    mouseInput.CallHandleMiddleMouseClick,
-                    mouseInput._mouseMiddleDraggingState,
-                    mouseInput.CurrentMouseState.MiddleButton);
-            }
+    private class MouseRightDownState : MouseButtonDownState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleRightMouseDown, mouseInput.CallHandleRightMouseDoubleClick);
         }
 
-        private class MouseMiddleDraggingState : MouseDraggingState
+        public override void Execute(MouseInput mouseInput)
         {
-            public override void Enter(MouseInput mouseInput)
-            {
-                EnterInternal(mouseInput, mouseInput.CallHandleMiddleMouseDragging);
-            }
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleRightMouseUp,
+                mouseInput.CallHandleRightMouseClick,
+                mouseInput._mouseRightDraggingState,
+                mouseInput.CurrentMouseState.RightButton);
+        }
+    }
 
-            public override void Execute(MouseInput mouseInput)
-            {
-                ExecuteInternal(
-                    mouseInput,
-                    mouseInput.CallHandleMiddleMouseUp,
-                    mouseInput.CallHandleMiddleMouseDragging,
-                    mouseInput.CallHandleMiddleMouseDragDone,
-                    mouseInput.CurrentMouseState.MiddleButton
-                    );
-            }
+    private class MouseRightDraggingState : MouseDraggingState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleRightMouseDragging);
+        }
+
+        public override void Execute(MouseInput mouseInput)
+        {
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleRightMouseUp,
+                mouseInput.CallHandleRightMouseDragging,
+                mouseInput.CallHandleRightMouseDragDone,
+                mouseInput.CurrentMouseState.RightButton);
+        }
+    }
+
+    private class MouseMiddleDownState : MouseButtonDownState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleMiddleMouseDown, mouseInput.CallHandleMiddleMouseDoubleClick);
+        }
+
+        public override void Execute(MouseInput mouseInput)
+        {
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleMiddleMouseUp,
+                mouseInput.CallHandleMiddleMouseClick,
+                mouseInput._mouseMiddleDraggingState,
+                mouseInput.CurrentMouseState.MiddleButton);
+        }
+    }
+
+    private class MouseMiddleDraggingState : MouseDraggingState
+    {
+        public override void Enter(MouseInput mouseInput)
+        {
+            EnterInternal(mouseInput, mouseInput.CallHandleMiddleMouseDragging);
+        }
+
+        public override void Execute(MouseInput mouseInput)
+        {
+            ExecuteInternal(
+                mouseInput,
+                mouseInput.CallHandleMiddleMouseUp,
+                mouseInput.CallHandleMiddleMouseDragging,
+                mouseInput.CallHandleMiddleMouseDragDone,
+                mouseInput.CurrentMouseState.MiddleButton
+            );
         }
     }
 }

--- a/InputHandlers/MouseInput.cs
+++ b/InputHandlers/MouseInput.cs
@@ -308,6 +308,20 @@ public class MouseInput : IMouseInput
         _mouseStateMachine.SetPreviousState(_mouseStationaryState);
     }
 
+    /// <summary>
+    /// Use this if you want to suppress double click detection (clears left, middle and right all at once).
+    /// May be useful for scenarios where you want to suppress clicks under some circumstances e.g. if the user
+    /// double clicks a button to close a window rather than single clicks and the click is subsequently
+    /// detected afterwards incorrectly as a different action. You could call this after the window closes
+    /// to suppress the double click. 
+    /// </summary>
+    public void ResetDoubleClickDetection()
+    {
+        _mouseLeftDownState.ResetDoubleClickDetection();
+        _mouseRightDownState.ResetDoubleClickDetection();
+        _mouseMiddleDownState.ResetDoubleClickDetection();
+    }
+
     public string CurrentStateAsString()
     {
         return _mouseStateMachine.GetCurrentStateTypeName();
@@ -480,6 +494,11 @@ public class MouseInput : IMouseInput
         }
 
         public override void Reset(MouseInput mouseInput)
+        {
+            ResetDoubleClickDetection();
+        }
+
+        public void ResetDoubleClickDetection()
         {
             _detectDoubleClickTime = double.NegativeInfinity;
             _wasDoubleClickDone = false;

--- a/InputHandlers/State.cs
+++ b/InputHandlers/State.cs
@@ -2,13 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace InputHandlers.State
+namespace InputHandlers.State;
+
+public abstract class State<T>
 {
-    public abstract class State<T>
-    {
-        public abstract void Enter(T entity);
-        public abstract void Execute(T entity);
-        public abstract void Exit(T entity);
-        public abstract void Reset(T entity);
-    }
+    public abstract void Enter(T entity);
+    public abstract void Execute(T entity);
+    public abstract void Exit(T entity);
+    public abstract void Reset(T entity);
 }

--- a/InputHandlers/StateMachine.cs
+++ b/InputHandlers/StateMachine.cs
@@ -4,49 +4,48 @@ using System.Linq;
 
 using InputHandlers.State;
 
-namespace InputHandlers.StateMachine
+namespace InputHandlers.StateMachine;
+
+public class StateMachine<T>
 {
-    public class StateMachine<T>
+    private readonly T _owner;
+
+    public StateMachine(T owner)
     {
-        private readonly T _owner;
+        _owner = owner;
+        CurrentState = null;
+        PreviousState = null;
+    }
 
-        public StateMachine(T owner)
-        {
-            _owner = owner;
-            CurrentState = null;
-            PreviousState = null;
-        }
+    public State<T> CurrentState { get; private set; }
+    public State<T> PreviousState { get; private set; }
 
-        public State<T> CurrentState { get; private set; }
-        public State<T> PreviousState { get; private set; }
+    public void SetCurrentState(State<T> currentState)
+    {
+        CurrentState = currentState;
+    }
 
-        public void SetCurrentState(State<T> currentState)
-        {
-            CurrentState = currentState;
-        }
+    public void SetPreviousState(State<T> previousState)
+    {
+        PreviousState = previousState;
+    }
 
-        public void SetPreviousState(State<T> previousState)
-        {
-            PreviousState = previousState;
-        }
+    public void Update()
+    {
+        if (CurrentState != null)
+            CurrentState.Execute(_owner);
+    }
 
-        public void Update()
-        {
-            if (CurrentState != null)
-                CurrentState.Execute(_owner);
-        }
+    public void ChangeState(State<T> newState)
+    {
+        PreviousState = CurrentState;
+        CurrentState.Exit(_owner);
+        CurrentState = newState;
+        CurrentState.Enter(_owner);
+    }
 
-        public void ChangeState(State<T> newState)
-        {
-            PreviousState = CurrentState;
-            CurrentState.Exit(_owner);
-            CurrentState = newState;
-            CurrentState.Enter(_owner);
-        }
-
-        public string GetCurrentStateTypeName()
-        {
-            return CurrentState.GetType().Name;
-        }
+    public string GetCurrentStateTypeName()
+    {
+        return CurrentState.GetType().Name;
     }
 }

--- a/InputHandlers/StopwatchProvider.cs
+++ b/InputHandlers/StopwatchProvider.cs
@@ -3,35 +3,34 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace InputHandlers
+namespace InputHandlers;
+
+public class StopwatchProvider : IStopwatchProvider
 {
-    public class StopwatchProvider : IStopwatchProvider
+    private readonly Stopwatch _stopwatch;
+
+    public StopwatchProvider()
     {
-        private readonly Stopwatch _stopwatch;
+        _stopwatch = new Stopwatch();
+    }
 
-        public StopwatchProvider()
-        {
-            _stopwatch = new Stopwatch();
-        }
+    public void Start()
+    {
+        _stopwatch.Start();
+    }
 
-        public void Start()
-        {
-            _stopwatch.Start();
-        }
+    public void Stop()
+    {
+        _stopwatch.Stop();
+    }
 
-        public void Stop()
-        {
-            _stopwatch.Stop();
-        }
+    public void Reset()
+    {
+        _stopwatch.Reset();
+    }
 
-        public void Reset()
-        {
-            _stopwatch.Reset();
-        }
-
-        public TimeSpan Elapsed
-        {
-            get { return _stopwatch.Elapsed; }
-        }
+    public TimeSpan Elapsed
+    {
+        get { return _stopwatch.Elapsed; }
     }
 }


### PR DESCRIPTION
Pending subscriptions are now internally time stamped. Prior to this, if you called Remove subscription and immediately performed Add with one of the added objects being one of those in the set being removed then the add would not happen. Now the order of remove and add calls are known and this scenario will now work as expected.

Added WaitForNeutralStateBeforeApplyingNewSubscriptions flag so that you can suppress events being fired to a new subscription until a neutral state has been achieved (i.e. for mouse, mouse is not moving and no buttons pressed, and for keyboard, no keys are down).

Added ResetDoubleClickDetection() method so that you can manually reset the double click detection state. As an example, this can be useful if you want to suppress a double click from happening after a single click has been handled. 